### PR TITLE
Fixed error with Theme

### DIFF
--- a/frontend/src/components/config/Theme.tsx
+++ b/frontend/src/components/config/Theme.tsx
@@ -24,6 +24,8 @@ export const ThemeConfig: any = {
   },
 };
 
+export type ThemeType = typeof ThemeConfig;
+
 const Theme = ({ children }: any) => (
   <ThemeProvider theme={ThemeConfig}>{children}</ThemeProvider>
 );

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
-import { createGlobalStyle, DefaultTheme } from 'styled-components';
+import { createGlobalStyle } from 'styled-components';
 import 'typeface-roboto';
 import App from './components/config/App';
 import * as serviceWorker from './serviceWorker';

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
-import { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle, DefaultTheme } from 'styled-components';
 import 'typeface-roboto';
 import App from './components/config/App';
 import * as serviceWorker from './serviceWorker';
-import Theme from './components/config/Theme';
+import Theme, { ThemeType } from './components/config/Theme';
 
-const GlobalStyle = createGlobalStyle`
+const GlobalStyle = createGlobalStyle<{ theme: ThemeType }>`
   html {
     height: 100vh;
     min-width: 640px;


### PR DESCRIPTION
### List of Changes:

- in the `Theme.tsx` file, added a line to export the previously written `ThemeConfig` as a type.

- in `src/Index.tsx`, imported `DefaultTheme` and the new `ThemeType` which solved the problem of not being able to find the fields in DefaultTheme.  

### Notes:

- [This page](https://spectrum.chat/styled-components/general/i-cant-use-my-theme-in-createglobalstyle-function-styled-components-v4-react-v16-6-3~0978b404-ab71-45c9-8f75-0862abde4eb5) was where I found the solution to this issue. 

- Currently the `ThemeProvider` in lines 29-31 of Theme.tsx is not in use. Please let me know if they are necessary so I can figure out how to use them.
