### PR TITLE
Update maximum pool size to 2.

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,4 @@ spring.jpa.open-in-view=true
 spring.datasource.hikari.connectionTimeout=45000 
 spring.datasource.hikari.idleTimeout=600000 
 spring.datasource.hikari.maxLifetime=30000
+spring.datasource.hikari.maximumPoolSize=2


### PR DESCRIPTION
### List of Changes:
- Add the `maximumPoolSize` value to `application.properties`, and set it to `2`.

### Notes:
- This change will mean that each instance that is run will only have a maximum of two connections.
- You can view the current connections to the ClearDB MySQL database on the [ClearDB Dashboard](https://www.cleardb.com/database/details?id=C4B08F39FC48CE1218433BB5EF0C4F7D). You can also navigate there by going to the [Heroku Dashboard](https://dashboard.heroku.com/apps/rocketden), click on the "ClearDB MySQL" installed add-on, and finally click the database name.
- We first changed this to `1` because we were getting a `max_user_connections` error which said that we had reached the maximum number of connections of `10`. When we modified the pool size, this error was fixed because each instance of the application running would only have `1` connection. However, this created a new error; the POST requests were not complete, and would simply run until the `connectionTimeout` value (45 seconds) was hit. When we changed this value to `2`, this  issue was resolved. [[1]](https://dba.stackexchange.com/questions/47131/how-to-get-rid-of-maximum-user-connections-error)
- The `maxLifetime` value means that the connection will be reset at 30 seconds. The `connectionTimeout` value means that the connection will shut down after 60 seconds. If `maxLifetime < connectionTimeout`, then `connectionTimeout` will not be reached.
- There is also a `max_questions` error; this may have to do with database limits, but it doesn't seem like we reached those, so we don't know what caused this. For now, I say we just continue to develop the app as normal unless the issue comes up again. [[1]](https://stackoverflow.com/questions/33046494/how-to-solve-exceeded-the-max-questions-resource-in-mysql-which-is-in-shared-h)