### PR TITLE
Create the Waiting Room page and Update the Create and Join pages.

### DIFF
--- a/frontend/src/components/config/App.tsx
+++ b/frontend/src/components/config/App.tsx
@@ -9,6 +9,7 @@ import GameLayout from '../layout/Game';
 import JoinGamePage from '../../views/Join';
 import CreateGamePage from '../../views/Create';
 import GameResultsPage from '../../views/Results';
+import WaitingRoomPage from '../../views/Waiting';
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
       <CustomRoute path="/game" component={GamePage} layout={GameLayout} exact />
       <CustomRoute path="/game/join" component={JoinGamePage} layout={MainLayout} exact />
       <CustomRoute path="/game/create" component={CreateGamePage} layout={MainLayout} exact />
+      <CustomRoute path="/game/waiting" component={WaitingRoomPage} layout={MainLayout} exact />
       <CustomRoute path="/game/results" component={GameResultsPage} layout={GameLayout} exact />
       <CustomRoute path="*" component={NotFound} layout={MainLayout} />
     </Switch>

--- a/frontend/src/components/config/App.tsx
+++ b/frontend/src/components/config/App.tsx
@@ -9,7 +9,7 @@ import GameLayout from '../layout/Game';
 import JoinGamePage from '../../views/Join';
 import CreateGamePage from '../../views/Create';
 import GameResultsPage from '../../views/Results';
-import WaitingRoomPage from '../../views/Waiting';
+import LobbyPage from '../../views/Lobby';
 
 function App() {
   return (
@@ -18,7 +18,7 @@ function App() {
       <CustomRoute path="/game" component={GamePage} layout={GameLayout} exact />
       <CustomRoute path="/game/join" component={JoinGamePage} layout={MainLayout} exact />
       <CustomRoute path="/game/create" component={CreateGamePage} layout={MainLayout} exact />
-      <CustomRoute path="/game/waiting" component={WaitingRoomPage} layout={MainLayout} exact />
+      <CustomRoute path="/game/lobby" component={LobbyPage} layout={MainLayout} exact />
       <CustomRoute path="/game/results" component={GameResultsPage} layout={GameLayout} exact />
       <CustomRoute path="*" component={NotFound} layout={MainLayout} />
     </Switch>

--- a/frontend/src/views/Create.tsx
+++ b/frontend/src/views/Create.tsx
@@ -10,10 +10,8 @@ function CreateGamePage() {
 
   // Creates a room with the user as the host, and joins that same waiting room.
   const createJoinWaitingRoom = (nickname: string) => new Promise<undefined>((resolve, reject) => {
-    const redirectToWaitingRoom = (room: Room, initialPageState: number,
-      initialNickname: string) => {
-      history.push(`/game/join?room=${room.roomId}`,
-        { initialPageState, initialNickname });
+    const redirectToWaitingRoom = (room: Room) => {
+      history.push(`/game/waiting?room=${room.roomId}`, { nickname });
     };
 
     const roomHost: RoomParams = {
@@ -23,7 +21,7 @@ function CreateGamePage() {
     };
     createRoom(roomHost)
       .then((res) => {
-        redirectToWaitingRoom(res, 2, nickname);
+        redirectToWaitingRoom(res);
         resolve();
       }).catch((err) => {
         reject(errorHandler(err.message));

--- a/frontend/src/views/Create.tsx
+++ b/frontend/src/views/Create.tsx
@@ -8,10 +8,10 @@ function CreateGamePage() {
   // Get history object to be able to move between different pages
   const history = useHistory();
 
-  // Creates a room with the user as the host, and joins that same waiting room.
-  const createJoinWaitingRoom = (nickname: string) => new Promise<undefined>((resolve, reject) => {
-    const redirectToWaitingRoom = (room: Room) => {
-      history.push(`/game/waiting?room=${room.roomId}`, { nickname });
+  // Creates a room with the user as the host, and joins that same lobby.
+  const createJoinLobby = (nickname: string) => new Promise<undefined>((resolve, reject) => {
+    const redirectToLobby = (room: Room) => {
+      history.push(`/game/lobby?room=${room.roomId}`, { nickname });
     };
 
     const roomHost: RoomParams = {
@@ -21,7 +21,7 @@ function CreateGamePage() {
     };
     createRoom(roomHost)
       .then((res) => {
-        redirectToWaitingRoom(res);
+        redirectToLobby(res);
         resolve();
       }).catch((err) => {
         reject(errorHandler(err.message));
@@ -32,7 +32,7 @@ function CreateGamePage() {
   return (
     <EnterNicknamePage
       enterNicknameHeaderText="Enter a nickname to create the game!"
-      enterNicknameAction={createJoinWaitingRoom}
+      enterNicknameAction={createJoinLobby}
     />
   );
 }

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -1,154 +1,27 @@
-import React, { useState, ReactElement } from 'react';
-import { useLocation } from 'react-router-dom';
-import { Message } from 'stompjs';
-import { LargeText, UserNicknameText } from '../components/core/Text';
+import React from 'react';
+import { useHistory } from 'react-router-dom';
 import EnterNicknamePage from '../components/core/EnterNickname';
-import { errorHandler } from '../api/Error';
-import {
-  addUser, SUBSCRIBE_URL,
-  connect, deleteUser, SOCKET_ENDPOINT, subscribe, User,
-} from '../api/Socket';
-import ErrorMessage from '../components/core/Error';
-
-type JoinGamePageProps = {
-  initialPageState?: number,
-  initialNickname?: string;
-}
 
 function JoinGamePage() {
-  // Grab initial state variables if navigated from the create page.
-  const location = useLocation<JoinGamePageProps>();
-  const joinGamePageProps: JoinGamePageProps = {};
-  if (location && location.state) {
-    joinGamePageProps.initialPageState = location.state.initialPageState;
-    joinGamePageProps.initialNickname = location.state.initialNickname;
-  }
-
-  // Hold error text.
-  const [error, setError] = useState('');
-
-  // Variable to hold the users on the page.
-  const [users, setUsers] = useState<User[]>([]);
-
-  // Variable to hold whether the user is connected to the socket.
-  const [socketConnected, setSocketConnected] = useState(false);
+  // Get history object to be able to move between different pages
+  const history = useHistory();
 
   /**
-   * Stores the current page state, where:
-   * 0 = Enter room ID state (currently unused)
-   * 1 = Enter nickname state
-   * 2 = Waiting room state
+   * Redirect the user to the waiting room.
    */
-  const [pageState, setPageState] = useState(joinGamePageProps.initialPageState || 1);
+  const redirectToWaitingRoom = (nickname: string) => new Promise<undefined>((resolve) => {
+    history.push('/game/waiting', { nickname });
+    resolve();
+  });
 
-  /**
-   * Nickname that is populated if the join page is on the waiting room stage.
-   * Set error if no nickname is passed in despite the waiting room stage.
-   */
-  const [nickname, setNickname] = useState(joinGamePageProps.initialNickname || '');
-  if (pageState === 2 && !nickname && !error) {
-    setError('No nickname was provided for the user in the waiting room.');
-  }
-
-  /**
-   * Subscribe callback that will be triggered on every message.
-   * Update the users list.
-   */
-  const subscribeCallback = (result: Message) => {
-    const userObjects:User[] = JSON.parse(result.body);
-    setUsers(userObjects);
-  };
-
-  /**
-   * Add the user to the waiting room through the following steps.
-   * 1. Connect the user to the socket.
-   * 2. Subscribe the user to future messages.
-   * 3. Send the user nickname to the room.
-   * 4. Update the room layout to the "waiting room" page.
-   * This method returns a Promise which is used to trigger setLoading
-   * and setError on the EnterNickname page following this function.
-   */
-  const addUserToWaitingRoom = (socketEndpoint: string,
-    subscribeUrl: string, nicknameParam: string) => new Promise<undefined>((resolve, reject) => {
-      connect(socketEndpoint).then(() => {
-        subscribe(subscribeUrl, subscribeCallback).then(() => {
-          try {
-            addUser(nicknameParam);
-            /**
-             * Set the necessary variables for the waiting room page.
-             * The socket connection must be set before updating the page state,
-             * otherwise this whole method will re-run.
-             */
-            setNickname(nicknameParam);
-            setSocketConnected(true);
-            setPageState(2);
-            resolve();
-          } catch (err) {
-            reject(errorHandler(err.message));
-          }
-        }).catch((err) => {
-          reject(errorHandler(err.message));
-        });
-      }).catch((err) => {
-        reject(errorHandler(err.message));
-      });
-    });
-
-  /**
-   * If the user is on the waiting room page state but not connected:
-   * add the user to the waiting room (which connects them to the socket).
-   * (This occurs when the create page redirects the user to the waiting page.)
-   */
-  if (!socketConnected && pageState === 2 && nickname) {
-    addUserToWaitingRoom(SOCKET_ENDPOINT, SUBSCRIBE_URL, nickname);
-  }
-
-  // Create variable to hold the "Join Page" content.
-  let joinPageContent: ReactElement | undefined;
-
-  switch (pageState) {
-    case 1:
-      // Render the "Enter nickname" state.
-      joinPageContent = (
-        <EnterNicknamePage
-          enterNicknameHeaderText="Enter a nickname to join the game!"
-          // Partial application of addUserToWaitingRoom function.
-          enterNicknameAction={
-            (nicknameParam: string) => addUserToWaitingRoom(SOCKET_ENDPOINT,
-              SUBSCRIBE_URL, nicknameParam)
-          }
-        />
-      );
-      break;
-    case 2:
-      // Render the Waiting room state.
-      joinPageContent = (
-        <div>
-          <LargeText>
-            You have entered the waiting room! Your nickname is &quot;
-            {nickname}
-            &quot;.
-          </LargeText>
-          { error ? <ErrorMessage message={error} /> : null }
-          <div>
-            {
-              users.map((user) => (
-                <UserNicknameText onClick={(event) => {
-                  deleteUser((event.target as HTMLElement).innerText);
-                }}
-                >
-                  {user.nickname}
-                </UserNicknameText>
-              ))
-            }
-          </div>
-        </div>
-      );
-      break;
-    default:
-  }
-
-  return joinPageContent;
+  // Render the "Enter nickname" state.
+  return (
+    <EnterNicknamePage
+      enterNicknameHeaderText="Enter a nickname to join the game!"
+      // Partial application of addUserToWaitingRoom function.
+      enterNicknameAction={redirectToWaitingRoom}
+    />
+  );
 }
 
 export default JoinGamePage;

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -7,10 +7,10 @@ function JoinGamePage() {
   const history = useHistory();
 
   /**
-   * Redirect the user to the waiting room.
+   * Redirect the user to the lobby.
    */
-  const redirectToWaitingRoom = (nickname: string) => new Promise<undefined>((resolve) => {
-    history.push('/game/waiting', { nickname });
+  const redirectToLobby = (nickname: string) => new Promise<undefined>((resolve) => {
+    history.push('/game/lobby', { nickname });
     resolve();
   });
 
@@ -18,8 +18,8 @@ function JoinGamePage() {
   return (
     <EnterNicknamePage
       enterNicknameHeaderText="Enter a nickname to join the game!"
-      // Partial application of addUserToWaitingRoom function.
-      enterNicknameAction={redirectToWaitingRoom}
+      // Partial application of addUserToLobby function.
+      enterNicknameAction={redirectToLobby}
     />
   );
 }

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -8,12 +8,12 @@ import {
 } from '../api/Socket';
 import ErrorMessage from '../components/core/Error';
 
-type LobbyPageProps = {
+type LobbyPageLocation = {
   nickname: string;
 }
 
 function LobbyPage() {
-  const location = useLocation<LobbyPageProps>();
+  const location = useLocation<LobbyPageLocation>();
   let nickname: string = '';
   if (location && location.state && location.state.nickname) {
     nickname = location.state.nickname;

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Message } from 'stompjs';
 import { LargeText, UserNicknameText } from '../components/core/Text';
@@ -41,12 +41,11 @@ function LobbyPage() {
    * 1. Connect the user to the socket.
    * 2. Subscribe the user to future messages.
    * 3. Send the user nickname to the room.
-   * 4. Update the room layout to the "lobby" page.
-   * This method returns a Promise which is used to trigger setLoading
-   * and setError on the EnterNickname page following this function.
+   * This method uses useCallback so it is not re-built in
+   * the useEffect function.
    */
-  const connectUserToRoom = (socketEndpoint: string, subscribeUrl: string,
-    nicknameParam: string) => {
+  const connectUserToRoom = useCallback((socketEndpoint: string,
+    subscribeUrl: string, nicknameParam: string) => {
     connect(socketEndpoint).then(() => {
       subscribe(subscribeUrl, subscribeCallback).then(() => {
         try {
@@ -61,7 +60,7 @@ function LobbyPage() {
     }).catch((err) => {
       setError(err.message);
     });
-  };
+  }, []);
 
   // Grab the nickname variable and add the user to the lobby.
   useEffect(() => {
@@ -71,15 +70,12 @@ function LobbyPage() {
     } else {
       setError('No nickname was provided for the user in the lobby.');
     }
-  }, [location]);
 
-  // Check if the socket should be connected when the nickname is updated.
-  useEffect(() => {
     // Connect the user to the room.
     if (!socketConnected && nickname) {
       connectUserToRoom(SOCKET_ENDPOINT, SUBSCRIBE_URL, nickname);
     }
-  }, [socketConnected, nickname, connectUserToRoom]);
+  }, [location, socketConnected, nickname, connectUserToRoom]);
 
   // Render the lobby.
   return (

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Message } from 'stompjs';
 import { LargeText, UserNicknameText } from '../components/core/Text';
@@ -14,10 +14,9 @@ type LobbyPageLocation = {
 
 function LobbyPage() {
   const location = useLocation<LobbyPageLocation>();
-  let nickname: string = '';
-  if (location && location.state && location.state.nickname) {
-    nickname = location.state.nickname;
-  }
+
+  // Set the nickname variable.
+  const [nickname, setNickname] = useState('');
 
   // Hold error text.
   const [error, setError] = useState('');
@@ -27,14 +26,6 @@ function LobbyPage() {
 
   // Variable to hold whether the user is connected to the socket.
   const [socketConnected, setSocketConnected] = useState(false);
-
-  /**
-   * Nickname that is populated if the join page is on the lobby stage.
-   * Set error if no nickname is passed in despite the lobby stage.
-   */
-  if (!nickname && !error) {
-    setError('No nickname was provided for the user in the lobby.');
-  }
 
   /**
    * Subscribe callback that will be triggered on every message.
@@ -72,14 +63,23 @@ function LobbyPage() {
     });
   };
 
-  /**
-   * If the user is on the lobby page state but not connected:
-   * add the user to the lobby (which connects them to the socket).
-   * (This occurs when the create page redirects the user to the lobby.)
-   */
-  if (!socketConnected && nickname) {
-    connectUserToRoom(SOCKET_ENDPOINT, SUBSCRIBE_URL, nickname);
-  }
+  // Grab the nickname variable and add the user to the lobby.
+  useEffect(() => {
+    // Grab the nickname variable; otherwise, set an error.
+    if (location && location.state && location.state.nickname) {
+      setNickname(location.state.nickname);
+    } else {
+      setError('No nickname was provided for the user in the lobby.');
+    }
+  }, [location]);
+
+  // Check if the socket should be connected when the nickname is updated.
+  useEffect(() => {
+    // Connect the user to the room.
+    if (!socketConnected && nickname) {
+      connectUserToRoom(SOCKET_ENDPOINT, SUBSCRIBE_URL, nickname);
+    }
+  }, [nickname]);
 
   // Render the lobby.
   return (

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -79,7 +79,7 @@ function LobbyPage() {
     if (!socketConnected && nickname) {
       connectUserToRoom(SOCKET_ENDPOINT, SUBSCRIBE_URL, nickname);
     }
-  }, [nickname]);
+  }, [socketConnected, nickname, connectUserToRoom]);
 
   // Render the lobby.
   return (

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -8,13 +8,16 @@ import {
 } from '../api/Socket';
 import ErrorMessage from '../components/core/Error';
 
-type WaitingRoomPageProps = {
+type LobbyPageProps = {
   nickname: string;
 }
 
-function WaitingRoomPage() {
-  const location = useLocation<WaitingRoomPageProps>();
-  const { nickname } = location.state;
+function LobbyPage() {
+  const location = useLocation<LobbyPageProps>();
+  let nickname: string = '';
+  if (location && location.state && location.state.nickname) {
+    nickname = location.state.nickname;
+  }
 
   // Hold error text.
   const [error, setError] = useState('');
@@ -26,11 +29,11 @@ function WaitingRoomPage() {
   const [socketConnected, setSocketConnected] = useState(false);
 
   /**
-   * Nickname that is populated if the join page is on the waiting room stage.
-   * Set error if no nickname is passed in despite the waiting room stage.
+   * Nickname that is populated if the join page is on the lobby stage.
+   * Set error if no nickname is passed in despite the lobby stage.
    */
-  if ((!location || !location.state || !location.state.nickname) && !error) {
-    setError('No nickname was provided for the user in the waiting room.');
+  if (!nickname && !error) {
+    setError('No nickname was provided for the user in the lobby.');
   }
 
   /**
@@ -43,11 +46,11 @@ function WaitingRoomPage() {
   };
 
   /**
-   * Add the user to the waiting room through the following steps.
+   * Add the user to the lobby through the following steps.
    * 1. Connect the user to the socket.
    * 2. Subscribe the user to future messages.
    * 3. Send the user nickname to the room.
-   * 4. Update the room layout to the "waiting room" page.
+   * 4. Update the room layout to the "lobby" page.
    * This method returns a Promise which is used to trigger setLoading
    * and setError on the EnterNickname page following this function.
    */
@@ -70,19 +73,19 @@ function WaitingRoomPage() {
   };
 
   /**
-   * If the user is on the waiting room page state but not connected:
-   * add the user to the waiting room (which connects them to the socket).
-   * (This occurs when the create page redirects the user to the waiting page.)
+   * If the user is on the lobby page state but not connected:
+   * add the user to the lobby (which connects them to the socket).
+   * (This occurs when the create page redirects the user to the lobby.)
    */
   if (!socketConnected && nickname) {
     connectUserToRoom(SOCKET_ENDPOINT, SUBSCRIBE_URL, nickname);
   }
 
-  // Render the Waiting room state.
+  // Render the lobby.
   return (
     <div>
       <LargeText>
-        You have entered the waiting room! Your nickname is &quot;
+        You have entered the lobby! Your nickname is &quot;
         {nickname}
         &quot;.
       </LargeText>
@@ -103,4 +106,4 @@ function WaitingRoomPage() {
   );
 }
 
-export default WaitingRoomPage;
+export default LobbyPage;

--- a/frontend/src/views/Waiting.tsx
+++ b/frontend/src/views/Waiting.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { Message } from 'stompjs';
+import { LargeText, UserNicknameText } from '../components/core/Text';
+import {
+  addUser, SUBSCRIBE_URL, connect,
+  deleteUser, SOCKET_ENDPOINT, subscribe, User,
+} from '../api/Socket';
+import ErrorMessage from '../components/core/Error';
+
+type WaitingRoomPageProps = {
+  nickname: string;
+}
+
+function WaitingRoomPage() {
+  const location = useLocation<WaitingRoomPageProps>();
+  const { nickname } = location.state;
+
+  // Hold error text.
+  const [error, setError] = useState('');
+
+  // Variable to hold the users on the page.
+  const [users, setUsers] = useState<User[]>([]);
+
+  // Variable to hold whether the user is connected to the socket.
+  const [socketConnected, setSocketConnected] = useState(false);
+
+  /**
+   * Nickname that is populated if the join page is on the waiting room stage.
+   * Set error if no nickname is passed in despite the waiting room stage.
+   */
+  if ((!location || !location.state || !location.state.nickname) && !error) {
+    setError('No nickname was provided for the user in the waiting room.');
+  }
+
+  /**
+   * Subscribe callback that will be triggered on every message.
+   * Update the users list.
+   */
+  const subscribeCallback = (result: Message) => {
+    const userObjects:User[] = JSON.parse(result.body);
+    setUsers(userObjects);
+  };
+
+  /**
+   * Add the user to the waiting room through the following steps.
+   * 1. Connect the user to the socket.
+   * 2. Subscribe the user to future messages.
+   * 3. Send the user nickname to the room.
+   * 4. Update the room layout to the "waiting room" page.
+   * This method returns a Promise which is used to trigger setLoading
+   * and setError on the EnterNickname page following this function.
+   */
+  const connectUserToRoom = (socketEndpoint: string, subscribeUrl: string,
+    nicknameParam: string) => {
+    connect(socketEndpoint).then(() => {
+      subscribe(subscribeUrl, subscribeCallback).then(() => {
+        try {
+          addUser(nicknameParam);
+          setSocketConnected(true);
+        } catch (err) {
+          setError(err.message);
+        }
+      }).catch((err) => {
+        setError(err.message);
+      });
+    }).catch((err) => {
+      setError(err.message);
+    });
+  };
+
+  /**
+   * If the user is on the waiting room page state but not connected:
+   * add the user to the waiting room (which connects them to the socket).
+   * (This occurs when the create page redirects the user to the waiting page.)
+   */
+  if (!socketConnected && nickname) {
+    connectUserToRoom(SOCKET_ENDPOINT, SUBSCRIBE_URL, nickname);
+  }
+
+  // Render the Waiting room state.
+  return (
+    <div>
+      <LargeText>
+        You have entered the waiting room! Your nickname is &quot;
+        {nickname}
+        &quot;.
+      </LargeText>
+      { error ? <ErrorMessage message={error} /> : null }
+      <div>
+        {
+          users.map((user) => (
+            <UserNicknameText onClick={(event) => {
+              deleteUser((event.target as HTMLElement).innerText);
+            }}
+            >
+              {user.nickname}
+            </UserNicknameText>
+          ))
+        }
+      </div>
+    </div>
+  );
+}
+
+export default WaitingRoomPage;


### PR DESCRIPTION
### List of Changes:
- Create the Waiting Room page (this is essentially a variant of the old Join page, but without the `pageState`).
- Update the Create and Join pages as necessary (the Join page now simply redirects to the Waiting Room page on enter).

### Notes:
- The error that shows "The socket failed to connect." is now on the Waiting room page.
- Whenever you refresh on the Waiting room page, it will re-connect and re-add you as a user. In the future (maybe next PR?), we will be able to detect when somebody reloads or closes the tab, which will improve the user management.
- Eventually, if you go to the waiting room without a Room or Nickname, it will redirect the user to the appropriate Join or Create page.

### Screencast and Images:
There are no images as there are no major UI changes, and all of the page flow updates can be shown through the screencast below.

[Screencast of the Waiting Room Page](https://www.loom.com/share/8df757f482fa4400999adb439f028528)