### PR TITLE
Create the Enter Room ID page and incorporate local storage.

### DIFF
--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import EnterNicknamePage from '../components/core/EnterNickname';
-import ErrorMessage from '../components/core/Error';
 import { LargeCenterInputText, LargeInputButton } from '../components/core/Input';
 import { LargeText, Text } from '../components/core/Text';
 
@@ -98,7 +97,6 @@ function JoinGamePage() {
               The room ID must have exactly six digits (numbers 0 through 9).
             </Text>
           ) : null}
-          { /* error ? <ErrorMessage message={error} /> : null */ }
         </div>
       );
       break;

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -1,11 +1,27 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import EnterNicknamePage from '../components/core/EnterNickname';
 import ErrorMessage from '../components/core/Error';
 import { LargeCenterInputText, LargeInputButton } from '../components/core/Input';
 import { LargeText, Text } from '../components/core/Text';
 
+type JoinPageLocation = {
+  pageState: number,
+  roomId?: string;
+}
+
 function JoinGamePage() {
+  // Get history object to be able to move between different pages
+  const location = useLocation<JoinPageLocation>();
+
+  // Function to update the location variable upon entered room ID.
+  const updateLocation = (roomIdParam: string) => {
+    location.state = {
+      pageState: 2,
+      roomId: roomIdParam,
+    };
+  };
+
   // Get history object to be able to move between different pages
   const history = useHistory();
 
@@ -41,6 +57,22 @@ function JoinGamePage() {
     resolve();
   });
 
+  useEffect(() => {
+    // Set the room ID, if it is saved in location.
+    if (location && location.state && location.state.roomId) {
+      setRoomId(location.state.roomId);
+    }
+
+    // Set the current page state, or initialize it to one by default.
+    if (location && location.state && location.state.pageState) {
+      setPageState(location.state.pageState);
+    } else {
+      location.state = {
+        pageState: 1,
+      };
+    }
+  }, [location]);
+
   let joinPageContent: ReactElement | undefined;
 
   switch (pageState) {
@@ -70,6 +102,7 @@ function JoinGamePage() {
               if (event.key === 'Enter' && validRoomId) {
                 // TODO: Add room ID to location or whatnot.
                 setPageState(2);
+                updateLocation(roomId);
               }
             }}
           />

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -45,7 +45,7 @@ function JoinGamePage() {
    */
   const redirectToLobby = (nickname: string) => new Promise<undefined>((resolve) => {
     updateLocalStorage('1', '');
-    history.push('/game/lobby', { nickname });
+    history.push(`/game/lobby?room=${roomId}`, { nickname });
     resolve();
   });
 

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -105,7 +105,7 @@ function JoinGamePage() {
       joinPageContent = (
         <div>
           <EnterNicknamePage
-            enterNicknameHeaderText="Enter a nickname to join the game!"
+            enterNicknameHeaderText={`Enter a nickname to join room ${roomId}!`}
             // Partial application of addUserToLobby function.
             enterNicknameAction={redirectToLobby}
           />

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -34,18 +34,21 @@ function JoinGamePage() {
   const [focusInput, setFocusInput] = useState(false);
 
   /**
-   * Redirect the user to the lobby.
+   * The local storage is updated when the page state updates.
    */
-  const redirectToLobby = (nickname: string) => new Promise<undefined>((resolve) => {
-    history.push('/game/lobby', { nickname });
-    resolve();
-  });
-
-  // The local storage is updated when the page state updates.
   const updateLocalStorage = (pageStateParam: string, roomIdParam: string) => {
     localStorage.setItem('pageState', pageStateParam);
     localStorage.setItem('roomId', roomIdParam);
   };
+
+  /**
+   * Update local storage and redirect the user to the lobby.
+   */
+  const redirectToLobby = (nickname: string) => new Promise<undefined>((resolve) => {
+    updateLocalStorage('1', '');
+    history.push('/game/lobby', { nickname });
+    resolve();
+  });
 
   let joinPageContent: ReactElement | undefined;
 

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -1,10 +1,18 @@
-import React from 'react';
+import React, { ReactElement, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import EnterNicknamePage from '../components/core/EnterNickname';
 
 function JoinGamePage() {
   // Get history object to be able to move between different pages
   const history = useHistory();
+
+  /**
+   * Page state variable that defines whether the user is
+   * entering a room ID or a nickname.
+   * 1 = Enter Room ID
+   * 2 = Enter Nickname
+   */
+  const [pageState, setPageState] = useState(1);
 
   /**
    * Redirect the user to the lobby.
@@ -14,14 +22,62 @@ function JoinGamePage() {
     resolve();
   });
 
-  // Render the "Enter nickname" state.
-  return (
-    <EnterNicknamePage
-      enterNicknameHeaderText="Enter a nickname to join the game!"
-      // Partial application of addUserToLobby function.
-      enterNicknameAction={redirectToLobby}
-    />
-  );
+  let joinPageContent: ReactElement | undefined;
+
+  switch(pageState) {
+    case 1:
+      // Render the "Enter room ID" state.
+      joinPageContent = (
+        <LargeText>
+          {enterNicknameHeaderText}
+        </LargeText>
+        <LargeCenterInputText
+          placeholder="Your nickname"
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            setNickname(event.target.value);
+          }}
+          onFocus={() => {
+            setFocusInput(true);
+          }}
+          onBlur={() => {
+            setFocusInput(false);
+          }}
+          onKeyPress={(event) => {
+            if (event.key === 'Enter' && validNickname) {
+              enterNicknameActionUpdatePage(nickname);
+            }
+          }}
+        />
+        <LargeInputButton
+          onClick={() => {
+            enterNicknameActionUpdatePage(nickname);
+          }}
+          value="Enter"
+          // Input is disabled if no nickname exists, has a space, or is too long.
+          disabled={!validNickname}
+        />
+        { focusInput && !validNickname ? (
+          <Text>
+            The nickname must be non-empty, have no spaces, and be less than 16 characters.
+          </Text>
+        ) : null}
+        { loading ? <Loading /> : null }
+        { error ? <ErrorMessage message={error} /> : null }
+      );
+    case 2: 
+      // Render the "Enter nickname" state.
+      joinPageContent = (
+        <EnterNicknamePage
+          enterNicknameHeaderText="Enter a nickname to join the game!"
+          // Partial application of addUserToLobby function.
+          enterNicknameAction={redirectToLobby}
+        />
+      );
+    default: setPageState(1);
+  }
+  
+
+  return joinPageContent;
 }
 
 export default JoinGamePage;

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -1,6 +1,9 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import EnterNicknamePage from '../components/core/EnterNickname';
+import ErrorMessage from '../components/core/Error';
+import { LargeCenterInputText, LargeInputButton } from '../components/core/Input';
+import { LargeText, Text } from '../components/core/Text';
 
 function JoinGamePage() {
   // Get history object to be able to move between different pages
@@ -14,6 +17,22 @@ function JoinGamePage() {
    */
   const [pageState, setPageState] = useState(1);
 
+  // Variable to hold the user's current room ID input.
+  const [roomId, setRoomId] = useState('');
+
+  /**
+   * The nickname is valid if it is non-empty and has exactly
+   * six nonalphanumeric characters.
+   */
+  const isValidRoomId = (roomIdParam: string) => (roomIdParam.length === 6) && /^\d+$/.test(roomIdParam);
+  const [validRoomId, setValidRoomId] = useState(false);
+  useEffect(() => {
+    setValidRoomId(isValidRoomId(roomId));
+  }, [roomId]);
+
+  // Variable to hold whether the user is focused on the text input field.
+  const [focusInput, setFocusInput] = useState(false);
+
   /**
    * Redirect the user to the lobby.
    */
@@ -24,47 +43,55 @@ function JoinGamePage() {
 
   let joinPageContent: ReactElement | undefined;
 
-  switch(pageState) {
+  switch (pageState) {
     case 1:
       // Render the "Enter room ID" state.
       joinPageContent = (
-        <LargeText>
-          {enterNicknameHeaderText}
-        </LargeText>
-        <LargeCenterInputText
-          placeholder="Your nickname"
-          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-            setNickname(event.target.value);
-          }}
-          onFocus={() => {
-            setFocusInput(true);
-          }}
-          onBlur={() => {
-            setFocusInput(false);
-          }}
-          onKeyPress={(event) => {
-            if (event.key === 'Enter' && validNickname) {
-              enterNicknameActionUpdatePage(nickname);
-            }
-          }}
-        />
-        <LargeInputButton
-          onClick={() => {
-            enterNicknameActionUpdatePage(nickname);
-          }}
-          value="Enter"
-          // Input is disabled if no nickname exists, has a space, or is too long.
-          disabled={!validNickname}
-        />
-        { focusInput && !validNickname ? (
-          <Text>
-            The nickname must be non-empty, have no spaces, and be less than 16 characters.
-          </Text>
-        ) : null}
-        { loading ? <Loading /> : null }
-        { error ? <ErrorMessage message={error} /> : null }
+        <div>
+          <LargeText>
+            Enter the six-digit room ID to join the game!
+          </LargeText>
+          <LargeCenterInputText
+            placeholder="123456"
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              setRoomId(event.target.value);
+            }}
+            onFocus={() => {
+              setFocusInput(true);
+            }}
+            onBlur={() => {
+              setFocusInput(false);
+            }}
+            onKeyPress={(event) => {
+              // If the key pressed is not a number, do not add it to the input.
+              if (event.key < '0' || event.key > '9') {
+                event.preventDefault();
+              }
+              if (event.key === 'Enter' && validRoomId) {
+                // TODO: Add room ID to location or whatnot.
+                setPageState(2);
+              }
+            }}
+          />
+          <LargeInputButton
+            onClick={() => {
+              // TODO: Add room ID to location or whatnot.
+              setPageState(2);
+            }}
+            value="Enter"
+            // Input is disabled if no nickname exists, has a space, or is too long.
+            disabled={!validRoomId}
+          />
+          { focusInput && !validRoomId ? (
+            <Text>
+              The room ID must have exactly six digits (numbers 0 through 9).
+            </Text>
+          ) : null}
+          { /* error ? <ErrorMessage message={error} /> : null */ }
+        </div>
       );
-    case 2: 
+      break;
+    case 2:
       // Render the "Enter nickname" state.
       joinPageContent = (
         <EnterNicknamePage
@@ -73,9 +100,9 @@ function JoinGamePage() {
           enterNicknameAction={redirectToLobby}
         />
       );
+      break;
     default: setPageState(1);
   }
-  
 
   return joinPageContent;
 }

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -14,10 +14,10 @@ function JoinGamePage() {
    * 1 = Enter Room ID (default)
    * 2 = Enter Nickname
    */
-  const [pageState, setPageState] = useState(parseInt(localStorage.getItem('pageState') || '1', 10));
+  const [pageState, setPageState] = useState(1);
 
   // Variable to hold the user's current room ID input (default empty string).
-  const [roomId, setRoomId] = useState(localStorage.getItem('roomId') || '');
+  const [roomId, setRoomId] = useState('');
 
   /**
    * The nickname is valid if it is non-empty and has exactly
@@ -33,18 +33,9 @@ function JoinGamePage() {
   const [focusInput, setFocusInput] = useState(false);
 
   /**
-   * The local storage is updated when the page state updates.
-   */
-  const updateLocalStorage = (pageStateParam: string, roomIdParam: string) => {
-    localStorage.setItem('pageState', pageStateParam);
-    localStorage.setItem('roomId', roomIdParam);
-  };
-
-  /**
-   * Update local storage and redirect the user to the lobby.
+   * Redirect the user to the lobby.
    */
   const redirectToLobby = (nickname: string) => new Promise<undefined>((resolve) => {
-    updateLocalStorage('1', '');
     history.push(`/game/lobby?room=${roomId}`, { nickname });
     resolve();
   });
@@ -76,17 +67,13 @@ function JoinGamePage() {
                 event.preventDefault();
               }
               if (event.key === 'Enter' && validRoomId) {
-                // TODO: Add room ID to location or whatnot.
                 setPageState(2);
-                updateLocalStorage('2', roomId);
               }
             }}
           />
           <LargeInputButton
             onClick={() => {
-              // TODO: Add room ID to location or whatnot.
               setPageState(2);
-              updateLocalStorage('2', roomId);
             }}
             value="Enter"
             // Input is disabled if no nickname exists, has a space, or is too long.

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -92,7 +92,7 @@ function JoinGamePage() {
       joinPageContent = (
         <div>
           <EnterNicknamePage
-            enterNicknameHeaderText={`Enter a nickname to join room ${roomId}!`}
+            enterNicknameHeaderText={`Enter a nickname to join room #${roomId}!`}
             // Partial application of addUserToLobby function.
             enterNicknameAction={redirectToLobby}
           />


### PR DESCRIPTION
### List of Changes:
- Create the Enter Room ID page on the Join Room page (add back in `pageState`).
- Include `localStorage` to save the currently-entered `roomId` and current `pageState`.

### Notes:
- I attempted to use the `location` React hook to save the current state, but it didn't work, so I decided to use `localStorage` instead. This means that the state and `roomId` is saved across different tabs.
- The user is unable to enter any character except for digits `0` through `9`. We can change this if we decide to create alphanumeric room IDs.

### Screencast and Images:
[Screencast of the Enter Room ID Page and Flow](https://www.loom.com/share/7936709fd9c04e278d927fa7b68ea599)
- I added the `roomId` to show in the URL (`/game/lobby?roomId=XXXXXX`) after recording this screencast.

Image of the Room ID Page
<img width="1280" alt="Room ID Page" src="https://user-images.githubusercontent.com/7987279/94021123-88193180-fd68-11ea-9040-ca082bf0bb97.png">