### PR TITLE
Change room-user relationship to bidirectional database mapping 

### DIFF
--- a/src/main/java/com/rocketden/main/model/Room.java
+++ b/src/main/java/com/rocketden/main/model/Room.java
@@ -45,14 +45,13 @@ public class Room {
     @Setter(AccessLevel.PRIVATE)
     private Set<User> users = new HashSet<>();
 
-    // Always use the following methods when dealing modifying a room's users
     public void addUser(User user) {
         users.add(user);
         user.setRoom(this);
     }
 
-    public void removeUser(String nickname) {
-        User userToRemove = new User();
-        users.remove(userToRemove);
+    // Removes user if the nicknames match (based on equals/hashCode implementation)
+    public boolean removeUser(User user) {
+        return users.remove(user);
     }
 }

--- a/src/main/java/com/rocketden/main/model/Room.java
+++ b/src/main/java/com/rocketden/main/model/Room.java
@@ -1,5 +1,6 @@
 package com.rocketden.main.model;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,6 +15,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.Set;
 
 @Entity
@@ -29,10 +31,28 @@ public class Room {
 
     private LocalDateTime createdDateTime = LocalDateTime.now();
 
+    // host_id column in room table holds the primary key of the user host
     @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "host_id")
     private User host;
 
-    @OneToMany(targetEntity = User.class, cascade = CascadeType.ALL, fetch = FetchType.EAGER)
-    private Set<User> users;
+    /**
+     * Generated from all the matching room variables in the User class.
+     * If the room is deleted or users removed from this set, those users will also be deleted.
+     * Setter is set to private to ensure proper use of addUser and removeUser methods.
+     */
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Setter(AccessLevel.PRIVATE)
+    private Set<User> users = new HashSet<>();
+
+    // Always use the following methods when dealing modifying a room's users
+    public void addUser(User user) {
+        users.add(user);
+        user.setRoom(this);
+    }
+
+    public void removeUser(String nickname) {
+        User userToRemove = new User();
+        users.remove(userToRemove);
+    }
 }

--- a/src/main/java/com/rocketden/main/model/User.java
+++ b/src/main/java/com/rocketden/main/model/User.java
@@ -1,15 +1,18 @@
 package com.rocketden.main.model;
 
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Entity
 @Getter
 @Setter
@@ -17,8 +20,13 @@ public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    @EqualsAndHashCode.Exclude
     private Integer id;
-    
+
+    @EqualsAndHashCode.Include
     private String nickname;
+
+    // room_id column in user table holds the primary key of the room
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
 }

--- a/src/main/java/com/rocketden/main/model/User.java
+++ b/src/main/java/com/rocketden/main/model/User.java
@@ -25,8 +25,8 @@ public class User {
     @EqualsAndHashCode.Include
     private String nickname;
 
-    // This room_id column holds the primary key of the room (not the roomId variable)
+    // This column holds the primary key of the room (not the roomId variable)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "room_id")
+    @JoinColumn(name = "room_table_id")
     private Room room;
 }

--- a/src/main/java/com/rocketden/main/model/User.java
+++ b/src/main/java/com/rocketden/main/model/User.java
@@ -25,7 +25,7 @@ public class User {
     @EqualsAndHashCode.Include
     private String nickname;
 
-    // room_id column in user table holds the primary key of the room
+    // This room_id column holds the primary key of the room (not the roomId variable)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id")
     private Room room;

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -56,14 +56,12 @@ public class RoomService {
         }
 
         // Return error if user is already in the room
-        Set<User> users = room.getUsers();
-        if (users.contains(user)) {
+        if (room.getUsers().contains(user)) {
             throw new ApiException(RoomError.USER_ALREADY_PRESENT);
         }
 
         // Add the user to the room.
-        users.add(user);
-        room.setUsers(users);
+        room.addUser(user);
         repository.save(room);
 
         RoomDto roomDto = RoomMapper.toDto(room);
@@ -82,14 +80,10 @@ public class RoomService {
             throw new ApiException(UserError.INVALID_USER);
         }
 
-        // Add the host to a new user set.
-        Set<User> users = new HashSet<>();
-        users.add(host);
-
         Room room = new Room();
         room.setRoomId(generateRoomId());
         room.setHost(host);
-        room.setUsers(users);
+        room.addUser(host);
         repository.save(room);
 
         return RoomMapper.toDto(room);

--- a/src/test/java/com/rocketden/main/api/ProblemTests.java
+++ b/src/test/java/com/rocketden/main/api/ProblemTests.java
@@ -1,4 +1,4 @@
-package com.rocketden.main;
+package com.rocketden.main.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;

--- a/src/test/java/com/rocketden/main/api/RoomTests.java
+++ b/src/test/java/com/rocketden/main/api/RoomTests.java
@@ -1,4 +1,4 @@
-package com.rocketden.main;
+package com.rocketden.main.api;
 
 import com.rocketden.main.dto.room.CreateRoomRequest;
 import com.rocketden.main.dto.room.JoinRoomRequest;

--- a/src/test/java/com/rocketden/main/api/UserTests.java
+++ b/src/test/java/com/rocketden/main/api/UserTests.java
@@ -1,4 +1,4 @@
-package com.rocketden.main;
+package com.rocketden.main.api;
 
 import com.rocketden.main.dto.user.CreateUserRequest;
 import com.rocketden.main.dto.user.DeleteUserRequest;

--- a/src/test/java/com/rocketden/main/entity/RoomEntityTests.java
+++ b/src/test/java/com/rocketden/main/entity/RoomEntityTests.java
@@ -1,0 +1,57 @@
+package com.rocketden.main.entity;
+
+import com.rocketden.main.model.Room;
+import com.rocketden.main.model.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@SpringBootTest
+public class RoomEntityTests {
+
+    @Test
+    public void roomInitialization() {
+        Room room = new Room();
+
+        assertNull(room.getHost());
+        assertNotNull(room.getUsers());
+        assertTrue(room.getUsers().isEmpty());
+    }
+
+    @Test
+    public void addUserToRoomSet() {
+        Room room = new Room();
+
+        User user = new User();
+        user.setNickname("test");
+
+        room.addUser(user);
+
+        assertEquals(1, room.getUsers().size());
+        assertEquals(room, user.getRoom());
+    }
+
+    @Test
+    public void removeUserFromRoomSet() {
+        Room room = new Room();
+
+        User user = new User();
+        user.setNickname("test");
+        room.addUser(user);
+        
+        User userToRemove = new User();
+
+        userToRemove.setNickname("nonexistent");
+        assertFalse(room.removeUser(userToRemove));
+        assertTrue(room.getUsers().contains(user));
+
+        userToRemove.setNickname("test");
+        assertTrue(room.removeUser(userToRemove));
+        assertFalse(room.getUsers().contains(user));
+    }
+}

--- a/src/test/java/com/rocketden/main/mapper/RoomMapperTests.java
+++ b/src/test/java/com/rocketden/main/mapper/RoomMapperTests.java
@@ -23,13 +23,15 @@ public class RoomMapperTests {
     public void entityToDto() {
         User host = new User();
         host.setNickname("rocket");
+        User user = new User();
+        user.setNickname("test");
 
         Room room = new Room();
         room.setRoomId("012345");
         room.setHost(host);
 
         room.addUser(host);
-        room.addUser(new User());
+        room.addUser(user);
 
         RoomDto response = RoomMapper.toDto(room);
 

--- a/src/test/java/com/rocketden/main/mapper/RoomMapperTests.java
+++ b/src/test/java/com/rocketden/main/mapper/RoomMapperTests.java
@@ -13,7 +13,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -25,14 +24,12 @@ public class RoomMapperTests {
         User host = new User();
         host.setNickname("rocket");
 
-        Set<User> users = new HashSet<>();
-        users.add(host);
-        users.add(new User());
-
         Room room = new Room();
         room.setRoomId("012345");
         room.setHost(host);
-        room.setUsers(users);
+
+        room.addUser(host);
+        room.addUser(new User());
 
         RoomDto response = RoomMapper.toDto(room);
 

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -65,12 +65,6 @@ public class RoomServiceTests {
         // Verify join room request succeeds and returns correct response
         String roomId = "012345";
 
-        // Create host and users objects.
-        User host = new User();
-        host.setNickname("host");
-        Set<User> users = new HashSet<>();
-        users.add(host);
-
         User user = new User();
         user.setNickname("rocket");
         JoinRoomRequest request = new JoinRoomRequest();
@@ -79,14 +73,19 @@ public class RoomServiceTests {
 
         Room room = new Room();
         room.setRoomId(roomId);
+
+        // Create host
+        User host = new User();
+        host.setNickname("host");
         room.setHost(host);
-        room.setUsers(users);
+        room.addUser(host);
 
         // Mock repository to return room when called
         Mockito.doReturn(room).when(repository).findRoomByRoomId(eq(roomId));
         RoomDto response = service.joinRoom(request);
 
         assertEquals(roomId, response.getRoomId());
+        assertEquals(2, response.getUsers().size());
         assertTrue(response.getUsers().contains(request.getUser()));
 
         verify(template).convertAndSend(
@@ -125,9 +124,7 @@ public class RoomServiceTests {
         firstUser.setNickname("rocket");
         User secondUser = new User();
         secondUser.setNickname("rocket");
-        Set<User> users = new HashSet<>();
-        users.add(firstUser);
-        
+
         JoinRoomRequest request = new JoinRoomRequest();
         request.setUser(UserMapper.toDto(secondUser));
         request.setRoomId(roomId);
@@ -135,7 +132,7 @@ public class RoomServiceTests {
         Room room = new Room();
         room.setRoomId(roomId);
         room.setHost(firstUser);
-        room.setUsers(users);
+        room.addUser(firstUser);
 
         // Mock repository to return room when called
         Mockito.doReturn(room).when(repository).findRoomByRoomId(eq(roomId));
@@ -155,8 +152,7 @@ public class RoomServiceTests {
         host.setNickname("test");
 
         room.setHost(host);
-        room.setUsers(new HashSet<>());
-        room.getUsers().add(host);
+        room.addUser(host);
 
         GetRoomRequest request = new GetRoomRequest();
         request.setRoomId(roomId);

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -77,8 +77,8 @@ public class RoomServiceTests {
         // Create host
         User host = new User();
         host.setNickname("host");
-        room.setHost(host);
         room.addUser(host);
+        room.setHost(host);
 
         // Mock repository to return room when called
         Mockito.doReturn(room).when(repository).findRoomByRoomId(eq(roomId));
@@ -122,11 +122,11 @@ public class RoomServiceTests {
         // Define two identical, and make the first one the host and second one the joiner
         User firstUser = new User();
         firstUser.setNickname("rocket");
-        User secondUser = new User();
-        secondUser.setNickname("rocket");
+        UserDto newUser = new UserDto();
+        newUser.setNickname("rocket");
 
         JoinRoomRequest request = new JoinRoomRequest();
-        request.setUser(UserMapper.toDto(secondUser));
+        request.setUser(newUser);
         request.setRoomId(roomId);
 
         Room room = new Room();

--- a/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
+++ b/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
@@ -1,4 +1,4 @@
-package com.rocketden.main;
+package com.rocketden.main.socket;
 
 import com.rocketden.main.controller.v1.BaseRestController;
 import com.rocketden.main.dto.room.CreateRoomRequest;


### PR DESCRIPTION
### List of Changes:

* Update room and users to a bidirectional mapping
  * This eliminates the need for a room_users table in the database
* Create addUser and removeUser methods to ensure both ends of mapping are synced
  * These should now be used in place of `room.setUsers(...)` or `room.getUsers().add(...)`

### Notes:

* Tutorials that demonstrate how to create bidirectional mappings: [[1]](https://vladmihalcea.com/the-best-way-to-map-a-onetomany-association-with-jpa-and-hibernate/)  [[2]](https://www.baeldung.com/jpa-joincolumn-vs-mappedby)
* Optional explanation for how equals/hashCode meshes with all the database ids and key stuff [[3]](https://stackoverflow.com/questions/1638723/how-should-equals-and-hashcode-be-implemented-when-using-jpa-and-hibernate)
* Explanations for CascadeType [[4]](https://stackoverflow.com/questions/13027214/what-is-the-meaning-of-the-cascadetype-all-for-a-manytoone-jpa-association) and orphanRemoval [[5]](https://stackoverflow.com/questions/18813341/what-is-the-difference-between-cascadetype-remove-and-orphanremoval-in-jpa) - this theoretically should mean two things:
  1. When we delete a room from the database, all users will also be deleted from the database
  2. When a user is removed from a room's set of users, that user will be deleted in the database
* I think right now those are our desired behaviors as it makes deleting users a lot easier, although in the future if we want users to persist across multiple games, then we'd likely need to set orphanRemoval to false and CascadeType to PERSIST
  * If we do this, we'll also need to update the removeUsers method to set `user.room` to null in order to properly separate it from the room. This might require some design changes though as idk how to get the actual User object from the set without making an additional repository query (right now the user you pass to the removeUsers method is just a dummy user with a matching nickname, so setting room to null on that object likely won't have the right effect).

### Screencast and Images:

Room table:
<img width="542" alt="Room table" src="https://user-images.githubusercontent.com/24768574/94738852-df00a700-0324-11eb-8d09-015cc5715a19.png">

User table:
<img width="622" alt="User table" src="https://user-images.githubusercontent.com/24768574/94738843-dc9e4d00-0324-11eb-9ff5-9f3df4995c60.png">



