### PR TITLE
Join page query param

### DIFF
--- a/frontend/src/util/Utility.ts
+++ b/frontend/src/util/Utility.ts
@@ -13,3 +13,9 @@ export const checkLocationState = (location: any, ...params: string[]) => {
 
   return valid;
 };
+
+/**
+ * The roomId is valid if it is non-empty and has exactly six
+ * numeric characters.
+ */
+export const isValidRoomId = (roomIdParam: string): boolean => (roomIdParam.length === 6) && /^\d+$/.test(roomIdParam);

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -92,6 +92,7 @@ function JoinGamePage() {
   const urlParams = new URLSearchParams(window.location.search);
   const roomIdQueryParam = urlParams.get('room');
   if (!roomId && roomIdQueryParam && isValidRoomId(roomIdQueryParam)) {
+    console.log('Test');
     setRoomId(roomIdQueryParam);
     checkRoom(roomIdQueryParam);
   }
@@ -123,7 +124,7 @@ function JoinGamePage() {
                * If the key pressed is not a number or the roomId is
                * already at length 6, do not add it to the input.
                */
-              if (event.key < '0' || event.key > '9' || roomId.length >= 6) {
+              if (event.key < '0' || event.key > '9') {
                 event.preventDefault();
               }
               if (event.key === 'Enter' && validRoomId && !loading) {

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -90,11 +90,9 @@ function JoinGamePage() {
 
   // Get URL query params to determine if the roomId is provided.
   const urlParams = new URLSearchParams(window.location.search);
-  const roomIdQueryParam = urlParams.get('room');
+  const roomIdQueryParam = urlParams.get('room') || '';
   if (!roomId && roomIdQueryParam && isValidRoomId(roomIdQueryParam)) {
-    console.log('Test');
     setRoomId(roomIdQueryParam);
-    checkRoom(roomIdQueryParam);
   }
 
   let joinPageContent: ReactElement | undefined;
@@ -108,11 +106,13 @@ function JoinGamePage() {
             Enter the six-digit room ID to join the game!
           </LargeText>
           <LargeCenterInputText
+            id="roomIdInput"
             placeholder="123456"
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
               setError('');
               setRoomId(event.target.value);
             }}
+            value={roomId}
             onFocus={() => {
               setFocusInput(true);
             }}
@@ -124,7 +124,7 @@ function JoinGamePage() {
                * If the key pressed is not a number or the roomId is
                * already at length 6, do not add it to the input.
                */
-              if (event.key < '0' || event.key > '9') {
+              if (event.key < '0' || event.key > '9' || roomId.length >= 6) {
                 event.preventDefault();
               }
               if (event.key === 'Enter' && validRoomId && !loading) {

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -88,12 +88,17 @@ function JoinGamePage() {
       }).catch((err) => reject(err));
   });
 
-  // Get URL query params to determine if the roomId is provided.
-  const urlParams = new URLSearchParams(window.location.search);
-  const roomIdQueryParam = urlParams.get('room') || '';
-  if (!roomId && roomIdQueryParam && isValidRoomId(roomIdQueryParam)) {
-    setRoomId(roomIdQueryParam);
-  }
+  /**
+   * Get URL query params to determine if the roomId is provided.
+   * Only run on initial page load.
+   */
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const roomIdQueryParam = urlParams.get('room') || '';
+    if (roomIdQueryParam && isValidRoomId(roomIdQueryParam)) {
+      setRoomId(roomIdQueryParam);
+    }
+  }, [isValidRoomId, setRoomId]);
 
   let joinPageContent: ReactElement | undefined;
 

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -8,7 +8,7 @@ import { joinRoom, getRoom } from '../api/Room';
 import Loading from '../components/core/Loading';
 import ErrorMessage from '../components/core/Error';
 import { ErrorResponse } from '../api/Error';
-import { checkLocationState } from '../util/Utility';
+import { checkLocationState, isValidRoomId } from '../util/Utility';
 
 type JoinPageLocation = {
   error: ErrorResponse,
@@ -49,7 +49,6 @@ function JoinGamePage() {
    * The roomId is valid if it is non-empty and has exactly
    * six numeric characters.
    */
-  const isValidRoomId = (roomIdParam: string) => (roomIdParam.length === 6) && /^\d+$/.test(roomIdParam);
   const [validRoomId, setValidRoomId] = useState(false);
   useEffect(() => {
     setValidRoomId(isValidRoomId(roomId));

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -61,11 +61,11 @@ function JoinGamePage() {
   /**
    * Check if a room exists with the current roomId.
    */
-  const checkRoom = () => {
+  const checkRoom = (roomIdParam: string) => {
     // Only verify if previous REST call is not still running
     if (!loading) {
       setLoading(true);
-      getRoom(roomId)
+      getRoom(roomIdParam)
         .then(() => {
           setLoading(false);
           setPageState(2);
@@ -88,6 +88,13 @@ function JoinGamePage() {
         history.push(`/game/lobby?room=${roomId}`, { roomId, user });
       }).catch((err) => reject(err));
   });
+
+  // Get URL query params to determine if the roomId is provided.
+  const urlParams = new URLSearchParams(window.location.search);
+  const roomIdQueryParam = urlParams.get('room');
+  if (roomIdQueryParam && isValidRoomId(roomIdQueryParam)) {
+    checkRoom(roomIdQueryParam);
+  }
 
   let joinPageContent: ReactElement | undefined;
 
@@ -120,13 +127,13 @@ function JoinGamePage() {
                 event.preventDefault();
               }
               if (event.key === 'Enter' && validRoomId && !loading) {
-                checkRoom();
+                checkRoom(roomId);
               }
             }}
           />
           <LargeInputButton
             onClick={() => {
-              checkRoom();
+              checkRoom(roomId);
             }}
             value="Enter"
             // Input is disabled if loading or if no nickname exists, has a space, or is too long.

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -98,7 +98,7 @@ function JoinGamePage() {
     if (roomIdQueryParam && isValidRoomId(roomIdQueryParam)) {
       setRoomId(roomIdQueryParam);
     }
-  }, [isValidRoomId, setRoomId]);
+  }, [setRoomId]);
 
   let joinPageContent: ReactElement | undefined;
 

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -92,7 +92,6 @@ function JoinGamePage() {
   const urlParams = new URLSearchParams(window.location.search);
   const roomIdQueryParam = urlParams.get('room');
   if (!roomId && roomIdQueryParam && isValidRoomId(roomIdQueryParam)) {
-    console.log(roomIdQueryParam);
     setRoomId(roomIdQueryParam);
     checkRoom(roomIdQueryParam);
   }

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -91,7 +91,9 @@ function JoinGamePage() {
   // Get URL query params to determine if the roomId is provided.
   const urlParams = new URLSearchParams(window.location.search);
   const roomIdQueryParam = urlParams.get('room');
-  if (roomIdQueryParam && isValidRoomId(roomIdQueryParam)) {
+  if (!roomId && roomIdQueryParam && isValidRoomId(roomIdQueryParam)) {
+    console.log(roomIdQueryParam);
+    setRoomId(roomIdQueryParam);
     checkRoom(roomIdQueryParam);
   }
 

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -100,7 +100,7 @@ function LobbyPage() {
     if (!socketConnected && currentRoomId && currentUser) {
       connectUserToRoom(currentRoomId);
     }
-  }, [location, socketConnected, currentRoomId, connectUserToRoom]);
+  }, [location, socketConnected, currentRoomId, history, currentUser, connectUserToRoom]);
 
   // Render the lobby.
   return (

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -103,7 +103,7 @@ function LobbyPage() {
         // Using redirect instead of history prevents the back button from breaking
         <Redirect
           to={{
-            pathname: `/game/join${currentRoomId ? `room=${currentRoomId}` : null}`,
+            pathname: `/game/join${currentRoomId ? `room=${currentRoomId}` : ''}`,
             state: { error: errorHandler('Please join a room to access the lobby page.') },
           }}
         />

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -90,7 +90,7 @@ function LobbyPage() {
       const roomIdQueryParam: string | null = urlParams.get('room');
       if (roomIdQueryParam && isValidRoomId(roomIdQueryParam)) {
         setRoomId(roomIdQueryParam);
-        history.replace(`/game/join?room=${roomIdQueryParam}`, { roomIdQueryParam });
+        history.replace(`/game/join?room=${roomIdQueryParam}`);
       } else {
         history.replace('/game/join');
       }

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -92,7 +92,7 @@ function LobbyPage() {
         setRoomId(roomIdQueryParam);
         history.replace(`/game/join?room=${roomIdQueryParam}`, { roomIdQueryParam });
       } else {
-        history.replace('/game/join', {});
+        history.replace('/game/join');
       }
     }
 

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -116,7 +116,7 @@ function LobbyPage() {
       ) : null}
       <LargeText>
         You have entered the lobby for room
-        {' '}
+        {' #'}
         {currentRoomId}
         ! Your nickname is &quot;
         {currentUser?.nickname}

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -103,7 +103,7 @@ function LobbyPage() {
         // Using redirect instead of history prevents the back button from breaking
         <Redirect
           to={{
-            pathname: '/game/join',
+            pathname: `/game/join${currentRoomId ? `room=${currentRoomId}` : null}`,
             state: { error: errorHandler('Please join a room to access the lobby page.') },
           }}
         />

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -90,9 +90,9 @@ function LobbyPage() {
       const roomIdQueryParam: string | null = urlParams.get('room');
       if (roomIdQueryParam && isValidRoomId(roomIdQueryParam)) {
         setRoomId(roomIdQueryParam);
-        history.push(`/game/join?room=${roomIdQueryParam}`, { roomIdQueryParam });
+        history.replace(`/game/join?room=${roomIdQueryParam}`, { roomIdQueryParam });
       } else {
-        history.push('/game/join', {});
+        history.replace('/game/join', {});
       }
     }
 

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -7,7 +7,7 @@ import { connect, routes, subscribe } from '../api/Socket';
 import { getRoom, Room } from '../api/Room';
 import { User } from '../api/User';
 import { errorHandler } from '../api/Error';
-import { checkLocationState } from '../util/Utility';
+import { checkLocationState, isValidRoomId } from '../util/Utility';
 
 type LobbyPageLocation = {
   user: User,
@@ -87,11 +87,17 @@ function LobbyPage() {
         .then((res) => setStateFromRoom(res))
         .catch((err) => setError(err));
     } else {
+      // Get URL query params to determine if the roomId is provided.
+      const urlParams = new URLSearchParams(window.location.search);
+      const roomIdQueryParam: string | null = urlParams.get('room');
+      if (roomIdQueryParam && isValidRoomId(roomIdQueryParam)) {
+        setRoomId(roomIdQueryParam);
+      }
       setShouldRedirect(true);
     }
 
     // Connect the user to the room.
-    if (!socketConnected && currentRoomId) {
+    if (!socketConnected && currentRoomId && currentUser) {
       connectUserToRoom(currentRoomId);
     }
   }, [location, socketConnected, currentRoomId, connectUserToRoom]);
@@ -103,7 +109,7 @@ function LobbyPage() {
         // Using redirect instead of history prevents the back button from breaking
         <Redirect
           to={{
-            pathname: `/game/join${currentRoomId ? `room=${currentRoomId}` : ''}`,
+            pathname: `/game/join${currentRoomId ? `?room=${currentRoomId}` : ''}`,
             state: { error: errorHandler('Please join a room to access the lobby page.') },
           }}
         />

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -1,12 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useLocation, Redirect } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import { Message } from 'stompjs';
 import ErrorMessage from '../components/core/Error';
 import { LargeText, UserNicknameText } from '../components/core/Text';
 import { connect, routes, subscribe } from '../api/Socket';
 import { getRoom, Room } from '../api/Room';
 import { User } from '../api/User';
-import { errorHandler } from '../api/Error';
 import { checkLocationState, isValidRoomId } from '../util/Utility';
 
 type LobbyPageLocation = {
@@ -15,6 +14,8 @@ type LobbyPageLocation = {
 };
 
 function LobbyPage() {
+  // Get history object to be able to move between different pages
+  const history = useHistory();
   const location = useLocation<LobbyPageLocation>();
 
   // Set the current user
@@ -27,9 +28,6 @@ function LobbyPage() {
 
   // Hold error text.
   const [error, setError] = useState('');
-
-  // Variable to determine whether to redirect back to join page
-  const [shouldRedirect, setShouldRedirect] = useState(false);
 
   // Variable to hold whether the user is connected to the socket.
   const [socketConnected, setSocketConnected] = useState(false);
@@ -92,8 +90,10 @@ function LobbyPage() {
       const roomIdQueryParam: string | null = urlParams.get('room');
       if (roomIdQueryParam && isValidRoomId(roomIdQueryParam)) {
         setRoomId(roomIdQueryParam);
+        history.push(`/game/join?room=${roomIdQueryParam}`, { roomIdQueryParam });
+      } else {
+        history.push('/game/join', {});
       }
-      setShouldRedirect(true);
     }
 
     // Connect the user to the room.
@@ -105,15 +105,6 @@ function LobbyPage() {
   // Render the lobby.
   return (
     <div>
-      { shouldRedirect ? (
-        // Using redirect instead of history prevents the back button from breaking
-        <Redirect
-          to={{
-            pathname: `/game/join${currentRoomId ? `?room=${currentRoomId}` : ''}`,
-            state: { error: errorHandler('Please join a room to access the lobby page.') },
-          }}
-        />
-      ) : null}
       <LargeText>
         You have entered the lobby for room
         {' #'}


### PR DESCRIPTION
### List of Changes:
- Allow users to share the page link for other players to join, by redirecting them to the appropriate location.
- Replace the `<Redirect />` element with a `history` push -- see notes for my reasoning on this.
- Check the query params of the `join` and `lobby` pages for relevant `roomId` information.

### Notes:
- I replaced the `<Redirect />` element in the `lobby.tsx` file with `history` hook, as the redirect wasn't working properly. Specifically, when I redirected to `/game/join?room=<ROOM_ID_HERE>`, it wasn't recognizing the page, and threw a 404 error. When I refreshed that page, then it worked properly (I don't know why any of that is, but I suspect it has something to do with how React.js manages states and pages).
  - While there was originally a downside with the "back" button behaving strangely, that isn't an issue anymore -- I'm not sure why, but this doesn't seem to be a problem (see the screencast below). Another benefit of the `history` hook is that I can pass in `roomId` as a `location` parameter as well (and anything else we may want in the future).
  - That isn't to say that there isn't an argument to remove it -- so please let me know your thoughts.

### Screencast and Images:
No images are attached as this does not change the UI, just the flow.

[Screencast of the Share Lobby Page Functionality](https://www.loom.com/share/b5d3e713cdde4532a859e7a033d59c16)