### PR TITLE
Add PUT endpoint to change room hosts

### DIFF
--- a/src/main/java/com/rocketden/main/controller/v1/RoomController.java
+++ b/src/main/java/com/rocketden/main/controller/v1/RoomController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,8 +42,9 @@ public class RoomController extends BaseRestController {
         return new ResponseEntity<>(service.createRoom(request), HttpStatus.CREATED);
     }
 
-    @PutMapping("/rooms/host")
-    public ResponseEntity<RoomDto> updateRoomHost(@RequestBody UpdateHostRequest request) {
-        return new ResponseEntity<>(service.updateRoomHost(request), HttpStatus.OK);
+    @PutMapping("/rooms/{roomId}/host")
+    public ResponseEntity<RoomDto> updateRoomHost(@PathVariable String roomId,
+                                                  @RequestBody UpdateHostRequest request) {
+        return new ResponseEntity<>(service.updateRoomHost(roomId, request), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/rocketden/main/controller/v1/RoomController.java
+++ b/src/main/java/com/rocketden/main/controller/v1/RoomController.java
@@ -4,6 +4,7 @@ import com.rocketden.main.dto.room.CreateRoomRequest;
 import com.rocketden.main.dto.room.GetRoomRequest;
 import com.rocketden.main.dto.room.JoinRoomRequest;
 import com.rocketden.main.dto.room.RoomDto;
+import com.rocketden.main.dto.room.UpdateHostRequest;
 import com.rocketden.main.service.RoomService;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,5 +39,10 @@ public class RoomController extends BaseRestController {
     @PostMapping("/rooms")
     public ResponseEntity<RoomDto> createRoom(@RequestBody CreateRoomRequest request) {
         return new ResponseEntity<>(service.createRoom(request), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/rooms/host")
+    public ResponseEntity<RoomDto> updateRoomHost(@RequestBody UpdateHostRequest request) {
+        return new ResponseEntity<>(service.updateRoomHost(request), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/rocketden/main/dto/room/RoomDto.java
+++ b/src/main/java/com/rocketden/main/dto/room/RoomDto.java
@@ -4,7 +4,7 @@ import com.rocketden.main.dto.user.UserDto;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.Set;
+import java.util.List;
 
 @Getter
 @Setter
@@ -12,5 +12,5 @@ public class RoomDto {
 
     private String roomId;
     private UserDto host;
-    private Set<UserDto> users;
+    private List<UserDto> users;
 }

--- a/src/main/java/com/rocketden/main/dto/room/UpdateHostRequest.java
+++ b/src/main/java/com/rocketden/main/dto/room/UpdateHostRequest.java
@@ -1,0 +1,4 @@
+package com.rocketden.main.dto.room;
+
+public class UpdateHostRequest {
+}

--- a/src/main/java/com/rocketden/main/dto/room/UpdateHostRequest.java
+++ b/src/main/java/com/rocketden/main/dto/room/UpdateHostRequest.java
@@ -1,4 +1,13 @@
 package com.rocketden.main.dto.room;
 
+import com.rocketden.main.dto.user.UserDto;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class UpdateHostRequest {
+    private String roomId;
+    private UserDto initiator;
+    private UserDto newHost;
 }

--- a/src/main/java/com/rocketden/main/dto/room/UpdateHostRequest.java
+++ b/src/main/java/com/rocketden/main/dto/room/UpdateHostRequest.java
@@ -7,7 +7,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class UpdateHostRequest {
-    private String roomId;
     private UserDto initiator;
     private UserDto newHost;
 }

--- a/src/main/java/com/rocketden/main/exception/RoomError.java
+++ b/src/main/java/com/rocketden/main/exception/RoomError.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum RoomError implements ApiError {
 
+    INVALID_PERMISSIONS(HttpStatus.BAD_REQUEST, "You do not have permission to perform this action"),
     NO_HOST(HttpStatus.BAD_REQUEST, "There is no host provided."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "A room could not be found with the given id."),
     USER_ALREADY_PRESENT(HttpStatus.CONFLICT, "A user with the features provided has already joined the room.");

--- a/src/main/java/com/rocketden/main/exception/RoomError.java
+++ b/src/main/java/com/rocketden/main/exception/RoomError.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum RoomError implements ApiError {
 
-    INVALID_PERMISSIONS(HttpStatus.BAD_REQUEST, "You do not have permission to perform this action"),
+    INVALID_PERMISSIONS(HttpStatus.FORBIDDEN, "You do not have permission to perform this action"),
     NO_HOST(HttpStatus.BAD_REQUEST, "There is no host provided."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "A room could not be found with the given id."),
     USER_ALREADY_PRESENT(HttpStatus.CONFLICT, "A user with the features provided has already joined the room.");

--- a/src/main/java/com/rocketden/main/model/Room.java
+++ b/src/main/java/com/rocketden/main/model/Room.java
@@ -15,8 +15,8 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -43,7 +43,7 @@ public class Room {
      */
     @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
     @Setter(AccessLevel.PRIVATE)
-    private Set<User> users = new HashSet<>();
+    private List<User> users = new ArrayList<>();
 
     public void addUser(User user) {
         users.add(user);
@@ -53,5 +53,21 @@ public class Room {
     // Removes user if the nicknames match (based on equals/hashCode implementation)
     public boolean removeUser(User user) {
         return users.remove(user);
+    }
+
+    /**
+     * Given a user object, return the equivalent user object in this room's list
+     * of users, or null if it doesn't exist. The reason this is necessary is
+     * because, while a user object constructed from a client's UserDto might
+     * "equal" a user in the room at the application level, they are not the same at
+     * the database level (different primary keys). This method therefore returns the
+     * correct user object that's equal at both the application and database levels.
+     */
+    public User getEquivalentUser(User userToFind) {
+        int index = users.indexOf(userToFind);
+        if (index >= 0) {
+            return users.get(index);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/rocketden/main/model/Room.java
+++ b/src/main/java/com/rocketden/main/model/Room.java
@@ -66,7 +66,7 @@ public class Room {
      * @param userToFind the desired user to find
      * @return the equivalent user in the database
      */
-    
+
     public User getEquivalentUser(User userToFind) {
         int index = users.indexOf(userToFind);
         if (index >= 0) {

--- a/src/main/java/com/rocketden/main/model/Room.java
+++ b/src/main/java/com/rocketden/main/model/Room.java
@@ -62,7 +62,11 @@ public class Room {
      * "equal" a user in the room at the application level, they are not the same at
      * the database level (different primary keys). This method therefore returns the
      * correct user object that's equal at both the application and database levels.
+     *
+     * @param userToFind the desired user to find
+     * @return the equivalent user in the database
      */
+    
     public User getEquivalentUser(User userToFind) {
         int index = users.indexOf(userToFind);
         if (index >= 0) {

--- a/src/main/java/com/rocketden/main/model/Room.java
+++ b/src/main/java/com/rocketden/main/model/Room.java
@@ -64,9 +64,8 @@ public class Room {
      * correct user object that's equal at both the application and database levels.
      *
      * @param userToFind the desired user to find
-     * @return the equivalent user in the database
+     * @return the equivalent user in the database, or null if none exists
      */
-
     public User getEquivalentUser(User userToFind) {
         int index = users.indexOf(userToFind);
         if (index >= 0) {

--- a/src/main/java/com/rocketden/main/model/User.java
+++ b/src/main/java/com/rocketden/main/model/User.java
@@ -27,6 +27,6 @@ public class User {
 
     // room_id column in user table holds the primary key of the room
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "room_id")
+    @JoinColumn(name = "room_table_id")
     private Room room;
 }

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -8,6 +8,7 @@ import com.rocketden.main.dto.room.GetRoomRequest;
 import com.rocketden.main.dto.room.JoinRoomRequest;
 import com.rocketden.main.dto.room.RoomDto;
 import com.rocketden.main.dto.room.RoomMapper;
+import com.rocketden.main.dto.room.UpdateHostRequest;
 import com.rocketden.main.dto.user.UserMapper;
 import com.rocketden.main.exception.RoomError;
 import com.rocketden.main.exception.UserError;
@@ -19,8 +20,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
-import java.util.Set;
-import java.util.HashSet;
 import java.util.Random;
 
 @Service
@@ -98,6 +97,10 @@ public class RoomService {
         }
 
         return RoomMapper.toDto(room);
+    }
+
+    public RoomDto updateRoomHost(UpdateHostRequest request) {
+        return null;
     }
 
     // Send updates about new users to the client through sockets

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -131,6 +131,8 @@ public class RoomService {
          */
         room.setHost(newHost);
 
+        RoomDto roomDto = RoomMapper.toDto(room);
+        sendSocketUpdate(roomDto);
         return RoomMapper.toDto(room);
     }
 

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -99,8 +99,8 @@ public class RoomService {
         return RoomMapper.toDto(room);
     }
 
-    public RoomDto updateRoomHost(UpdateHostRequest request) {
-        Room room = repository.findRoomByRoomId(request.getRoomId());
+    public RoomDto updateRoomHost(String roomId, UpdateHostRequest request) {
+        Room room = repository.findRoomByRoomId(roomId);
 
         // Return error if room could not be found
         if (room == null) {

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -109,7 +109,7 @@ public class RoomService {
 
         // Get the initiator and proposed new host from the request
         User initiator = UserMapper.toEntity(request.getInitiator());
-        User newHost = UserMapper.toEntity(request.getNewHost());
+        User proposedNewHost = UserMapper.toEntity(request.getNewHost());
 
         // Return error if the initiator is not the host
         if (!room.getHost().equals(initiator)) {
@@ -117,18 +117,12 @@ public class RoomService {
         }
 
         // Return error if the proposed new host is not in the room
-        if (!room.getUsers().contains(newHost)) {
+        if (!room.getUsers().contains(proposedNewHost)) {
             throw new ApiException(UserError.NOT_FOUND);
         }
 
-        /*
-         * Possible bug: newHost (provided by client) is not exactly the
-         * same as the user in room.users (primary key mismatch), so this
-         * is essentially adding a new user as host instead of the one
-         * already in the room. This might work ok throughout the codebase
-         * due to the equals/hashCode implementation, but would likely lead
-         * to duplicate users in the database.
-         */
+        // Change the host to the new user
+        User newHost = room.getEquivalentUser(proposedNewHost);
         room.setHost(newHost);
         repository.save(room);
 

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -130,6 +130,7 @@ public class RoomService {
          * to duplicate users in the database.
          */
         room.setHost(newHost);
+        repository.save(room);
 
         RoomDto roomDto = RoomMapper.toDto(room);
         sendSocketUpdate(roomDto);

--- a/src/test/java/com/rocketden/main/api/RoomTests.java
+++ b/src/test/java/com/rocketden/main/api/RoomTests.java
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -481,6 +482,7 @@ public class RoomTests {
 
         assertEquals(host, room.getHost());
         assertEquals(2, room.getUsers().size());
+        assertTrue(room.getUsers().contains(user));
 
         return room;
     }

--- a/src/test/java/com/rocketden/main/api/RoomTests.java
+++ b/src/test/java/com/rocketden/main/api/RoomTests.java
@@ -5,7 +5,6 @@ import com.rocketden.main.dto.room.JoinRoomRequest;
 import com.rocketden.main.dto.room.RoomDto;
 import com.rocketden.main.dto.room.UpdateHostRequest;
 import com.rocketden.main.dto.user.UserDto;
-import com.rocketden.main.dto.room.GetRoomRequest;
 import com.rocketden.main.exception.RoomError;
 import com.rocketden.main.exception.UserError;
 import com.rocketden.main.exception.api.ApiError;
@@ -124,9 +123,6 @@ public class RoomTests {
         // Send GET request to validate that room exists
         String roomId = actual.getRoomId();
         expected.setRoomId(roomId);
-
-        GetRoomRequest request = new GetRoomRequest();
-        request.setRoomId(roomId);
 
         result = this.mockMvc.perform(get(GET_ROOM)
                 .param("roomId", roomId))
@@ -371,6 +367,19 @@ public class RoomTests {
 
         assertEquals(secondHost, room.getHost());
         assertEquals(2, room.getUsers().size());
+
+        // Confirm with a GET that the room has actually been updated in the database
+        result = this.mockMvc.perform(get(GET_ROOM)
+                .param("roomId", room.getRoomId()))
+                .andDo(print()).andExpect(status().isOk())
+                .andReturn();
+
+        jsonResponse = result.getResponse().getContentAsString();
+        RoomDto actual = Utility.toObject(jsonResponse, RoomDto.class);
+
+        assertEquals(room.getRoomId(), actual.getRoomId());
+        assertEquals(room.getHost(), actual.getHost());
+        assertEquals(room.getUsers(), actual.getUsers());
     }
 
     @Test

--- a/src/test/java/com/rocketden/main/api/RoomTests.java
+++ b/src/test/java/com/rocketden/main/api/RoomTests.java
@@ -43,7 +43,7 @@ public class RoomTests {
     private static final String GET_ROOM = "/api/v1/rooms";
     private static final String PUT_ROOM = "/api/v1/rooms";
     private static final String POST_ROOM = "/api/v1/rooms";
-    private static final String PUT_ROOM_HOST = "/api/v1/rooms/host";
+    private static final String PUT_ROOM_HOST = "/api/v1/rooms/%s/host";
 
     @Test
     public void getNonExistentRoom() throws Exception {
@@ -357,11 +357,10 @@ public class RoomTests {
 
         // Host sends request to change hosts
         UpdateHostRequest updateHostRequest = new UpdateHostRequest();
-        updateHostRequest.setRoomId(room.getRoomId());
         updateHostRequest.setInitiator(firstHost);
         updateHostRequest.setNewHost(secondHost);
 
-        result = this.mockMvc.perform(put(PUT_ROOM_HOST)
+        result = this.mockMvc.perform(put(String.format(PUT_ROOM_HOST, room.getRoomId()))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(Utility.convertObjectToJsonString(updateHostRequest)))
                 .andDo(print()).andExpect(status().isOk())
@@ -412,13 +411,12 @@ public class RoomTests {
 
         // Non-host tries to change hosts
         UpdateHostRequest updateHostRequest = new UpdateHostRequest();
-        updateHostRequest.setRoomId(room.getRoomId());
         updateHostRequest.setInitiator(user);
         updateHostRequest.setNewHost(host);
 
         ApiError ERROR = RoomError.INVALID_PERMISSIONS;
 
-        result = this.mockMvc.perform(put(PUT_ROOM_HOST)
+        result = this.mockMvc.perform(put(String.format(PUT_ROOM_HOST, room.getRoomId()))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(Utility.convertObjectToJsonString(updateHostRequest)))
                 .andDo(print()).andExpect(status().is(ERROR.getStatus().value()))
@@ -431,13 +429,12 @@ public class RoomTests {
 
         // Room does not exist
         updateHostRequest = new UpdateHostRequest();
-        updateHostRequest.setRoomId("999999");
         updateHostRequest.setInitiator(host);
         updateHostRequest.setNewHost(user);
 
         ERROR = RoomError.NOT_FOUND;
 
-        result = this.mockMvc.perform(put(PUT_ROOM_HOST)
+        result = this.mockMvc.perform(put(String.format(PUT_ROOM_HOST, "999999"))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(Utility.convertObjectToJsonString(updateHostRequest)))
                 .andDo(print()).andExpect(status().is(ERROR.getStatus().value()))
@@ -450,13 +447,12 @@ public class RoomTests {
 
         // New host does not exist in the room
         updateHostRequest = new UpdateHostRequest();
-        updateHostRequest.setRoomId(room.getRoomId());
         updateHostRequest.setInitiator(host);
         updateHostRequest.setNewHost(new UserDto());
 
         ERROR = UserError.NOT_FOUND;
 
-        result = this.mockMvc.perform(put(PUT_ROOM_HOST)
+        result = this.mockMvc.perform(put(String.format(PUT_ROOM_HOST, room.getRoomId()))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(Utility.convertObjectToJsonString(updateHostRequest)))
                 .andDo(print()).andExpect(status().is(ERROR.getStatus().value()))

--- a/src/test/java/com/rocketden/main/api/RoomTests.java
+++ b/src/test/java/com/rocketden/main/api/RoomTests.java
@@ -315,4 +315,14 @@ public class RoomTests {
 
         assertEquals(ERROR.getResponse(), actual);
     }
+
+    @Test
+    public void changeRoomHostSuccess() {
+        // Successfully change the room host
+    }
+
+    @Test
+    public void changeRoomHostFailure() {
+        // Error thrown when request is invalid (bad permissions, nonexistent room)
+    }
 }

--- a/src/test/java/com/rocketden/main/api/RoomTests.java
+++ b/src/test/java/com/rocketden/main/api/RoomTests.java
@@ -27,8 +27,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 @SpringBootTest(properties = "spring.datasource.type=com.zaxxer.hikari.HikariDataSource")
 @AutoConfigureMockMvc
@@ -104,7 +104,7 @@ public class RoomTests {
 
         RoomDto expected = new RoomDto();
         expected.setHost(host);
-        Set<UserDto> users = new HashSet<>();
+        List<UserDto> users = new ArrayList<>();
         users.add(host);
         expected.setUsers(users);
 
@@ -167,7 +167,7 @@ public class RoomTests {
         // 1. Send POST request and verify room was created
         RoomDto createExpected = new RoomDto();
         createExpected.setHost(host);
-        Set<UserDto> users = new HashSet<>();
+        List<UserDto> users = new ArrayList<>();
         users.add(host);
         createExpected.setUsers(users);
 
@@ -186,10 +186,10 @@ public class RoomTests {
         // Get id of created room to join
         String roomId = createActual.getRoomId();
 
-        // Create User and Set<User> for PUT request
+        // Create User and List<User> for PUT request
         UserDto user = new UserDto();
         user.setNickname("rocket");
-        users = new HashSet<>();
+        users = new ArrayList<>();
         users.add(host);
         users.add(user);
 
@@ -228,7 +228,7 @@ public class RoomTests {
         // 1. Send POST request and verify room was created
         RoomDto createExpected = new RoomDto();
         createExpected.setHost(host);
-        Set<UserDto> users = new HashSet<>();
+        List<UserDto> users = new ArrayList<>();
         users.add(host);
         createExpected.setUsers(users);
 
@@ -277,7 +277,7 @@ public class RoomTests {
         // 1. Send POST request and verify room was created
         RoomDto createExpected = new RoomDto();
         createExpected.setHost(host);
-        Set<UserDto> users = new HashSet<>();
+        List<UserDto> users = new ArrayList<>();
         users.add(host);
         createExpected.setUsers(users);
 

--- a/src/test/java/com/rocketden/main/entity/RoomEntityTests.java
+++ b/src/test/java/com/rocketden/main/entity/RoomEntityTests.java
@@ -42,16 +42,41 @@ public class RoomEntityTests {
 
         User user = new User();
         user.setNickname("test");
+        user.setId(1);
         room.addUser(user);
         
         User userToRemove = new User();
-
         userToRemove.setNickname("nonexistent");
+        user.setId(2);
+
         assertFalse(room.removeUser(userToRemove));
         assertTrue(room.getUsers().contains(user));
 
         userToRemove.setNickname("test");
         assertTrue(room.removeUser(userToRemove));
         assertFalse(room.getUsers().contains(user));
+    }
+
+    @Test
+    public void getEquivalentUserSucceeds() {
+        Room room = new Room();
+
+        User user = new User();
+        user.setNickname("test");
+        user.setId(1);
+        room.addUser(user);
+
+        User userToGet = new User();
+        userToGet.setNickname("nonexistent");
+        user.setId(2);
+
+        assertNull(room.getEquivalentUser(userToGet));
+
+        userToGet.setNickname("test");
+
+        User actual = room.getEquivalentUser(userToGet);
+
+        assertEquals(user.getNickname(), actual.getNickname());
+        assertEquals(user.getId(), actual.getId());
     }
 }

--- a/src/test/java/com/rocketden/main/entity/RoomEntityTests.java
+++ b/src/test/java/com/rocketden/main/entity/RoomEntityTests.java
@@ -47,7 +47,7 @@ public class RoomEntityTests {
         
         User userToRemove = new User();
         userToRemove.setNickname("nonexistent");
-        user.setId(2);
+        userToRemove.setId(2);
 
         assertFalse(room.removeUser(userToRemove));
         assertTrue(room.getUsers().contains(user));
@@ -68,7 +68,7 @@ public class RoomEntityTests {
 
         User userToGet = new User();
         userToGet.setNickname("nonexistent");
-        user.setId(2);
+        userToGet.setId(2);
 
         assertNull(room.getEquivalentUser(userToGet));
 

--- a/src/test/java/com/rocketden/main/mapper/RoomMapperTests.java
+++ b/src/test/java/com/rocketden/main/mapper/RoomMapperTests.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @SpringBootTest
@@ -40,10 +40,10 @@ public class RoomMapperTests {
         assertEquals(room.getHost(), actualHost);
 
         // Map set of UserDtos to set of Users
-        Set<User> actualUsers = response.getUsers()
+        List<User> actualUsers = response.getUsers()
                 .stream()
                 .map(UserMapper::toEntity)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
         assertEquals(room.getUsers(), actualUsers);
     }
 

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -197,11 +197,10 @@ public class RoomServiceTests {
         Mockito.doReturn(room).when(repository).findRoomByRoomId(eq(roomId));
 
         UpdateHostRequest request = new UpdateHostRequest();
-        request.setRoomId(room.getRoomId());
         request.setInitiator(UserMapper.toDto(host));
         request.setNewHost(UserMapper.toDto(user));
 
-        RoomDto response = service.updateRoomHost(request);
+        RoomDto response = service.updateRoomHost(room.getRoomId(), request);
 
         assertEquals(user, UserMapper.toEntity(response.getHost()));
     }
@@ -225,32 +224,32 @@ public class RoomServiceTests {
 
         // Invalid permissions
         UpdateHostRequest invalidPermRequest = new UpdateHostRequest();
-        invalidPermRequest.setRoomId(room.getRoomId());
         invalidPermRequest.setInitiator(UserMapper.toDto(user));
         invalidPermRequest.setNewHost(UserMapper.toDto(host));
 
-        ApiException exception = assertThrows(ApiException.class, () -> service.updateRoomHost(invalidPermRequest));
+        ApiException exception = assertThrows(ApiException.class, () ->
+                service.updateRoomHost(room.getRoomId(), invalidPermRequest));
         assertEquals(RoomError.INVALID_PERMISSIONS, exception.getError());
 
         // Nonexistent room
         UpdateHostRequest noRoomRequest = new UpdateHostRequest();
-        noRoomRequest.setRoomId("999999");
         noRoomRequest.setInitiator(UserMapper.toDto(host));
         noRoomRequest.setNewHost(UserMapper.toDto(user));
 
-        exception = assertThrows(ApiException.class, () -> service.updateRoomHost(noRoomRequest));
+        exception = assertThrows(ApiException.class, () ->
+                service.updateRoomHost("999999", noRoomRequest));
         assertEquals(RoomError.NOT_FOUND, exception.getError());
 
         // Nonexistent new host
         UpdateHostRequest noUserRequest = new UpdateHostRequest();
-        noUserRequest.setRoomId(room.getRoomId());
         noUserRequest.setInitiator(UserMapper.toDto(host));
 
         UserDto nonExistentUser = new UserDto();
         nonExistentUser.setNickname("notfound");
         noUserRequest.setNewHost(nonExistentUser);
 
-        exception = assertThrows(ApiException.class, () -> service.updateRoomHost(noUserRequest));
+        exception = assertThrows(ApiException.class, () ->
+                service.updateRoomHost(room.getRoomId(), noUserRequest));
         assertEquals(UserError.NOT_FOUND, exception.getError());
     }
 

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -176,6 +175,16 @@ public class RoomServiceTests {
         ApiException exception = assertThrows(ApiException.class, () -> service.getRoom(request));
 
         assertEquals(RoomError.NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    public void changeRoomHostSuccess() {
+
+    }
+
+    @Test
+    public void changeRoomHostFailure() {
+
     }
 
     @Test

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @ExtendWith(MockitoExtension.class)
@@ -164,8 +164,8 @@ public class RoomServiceTests {
         assertEquals(roomId, response.getRoomId());
         assertEquals(room.getHost(), UserMapper.toEntity(response.getHost()));
 
-        Set<User> actual = response.getUsers().stream()
-                .map(UserMapper::toEntity).collect(Collectors.toSet());
+        List<User> actual = response.getUsers().stream()
+                .map(UserMapper::toEntity).collect(Collectors.toList());
         assertEquals(room.getUsers(), actual);
     }
 

--- a/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
+++ b/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
@@ -149,7 +149,7 @@ public class RoomSocketTests {
         updateRequest.setNewHost(newUser);
 
         HttpEntity<UpdateHostRequest> updateEntity = new HttpEntity<>(updateRequest);
-        expected = template.exchange(baseRestEndpoint, HttpMethod.PUT, joinEntity, RoomDto.class).getBody();
+        expected = template.exchange(baseRestEndpoint + "/host", HttpMethod.PUT, updateEntity, RoomDto.class).getBody();
 
         // Verify that the socket receives a message with the updated host
         actual = blockingQueue.poll(3, SECONDS);

--- a/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
+++ b/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
@@ -27,9 +27,7 @@ import org.springframework.web.socket.sockjs.client.SockJsClient;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 
 import java.lang.reflect.Type;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
@@ -59,6 +57,8 @@ public class RoomSocketTests {
         this.stompClient = new WebSocketStompClient(new SockJsClient(
                 List.of(new WebSocketTransport(new StandardWebSocketClient()))));
         this.stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+        // TODO: move room creation and socket connection to here
     }
 
     @Test
@@ -116,6 +116,11 @@ public class RoomSocketTests {
         assertEquals(expected.getRoomId(), actual.getRoomId());
         assertEquals(expected.getHost(), actual.getHost());
         assertEquals(expected.getUsers(), actual.getUsers());
+    }
+
+    @Test
+    public void socketReceivesMessageOnHostChange() {
+
     }
 
 }

--- a/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
+++ b/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
@@ -4,6 +4,7 @@ import com.rocketden.main.controller.v1.BaseRestController;
 import com.rocketden.main.dto.room.CreateRoomRequest;
 import com.rocketden.main.dto.room.JoinRoomRequest;
 import com.rocketden.main.dto.room.RoomDto;
+import com.rocketden.main.dto.room.UpdateHostRequest;
 import com.rocketden.main.dto.user.UserDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,19 +53,18 @@ public class RoomSocketTests {
     private static final String CONNECT_ENDPOINT = "ws://localhost:{port}" + BaseRestController.BASE_SOCKET_URL + "/join-room-endpoint";
     private static final String SUBSCRIBE_ENDPOINT = BaseRestController.BASE_SOCKET_URL + "/%s/subscribe-user";
 
+    private BlockingQueue<RoomDto> blockingQueue;
+    private String baseRestEndpoint;
+    private String roomId;
+
     @BeforeEach
-    public void setup() {
+    public void setup() throws Exception {
         this.stompClient = new WebSocketStompClient(new SockJsClient(
                 List.of(new WebSocketTransport(new StandardWebSocketClient()))));
         this.stompClient.setMessageConverter(new MappingJackson2MessageConverter());
 
-        // TODO: move room creation and socket connection to here
-    }
-
-    @Test
-    public void socketReceivesMessageOnJoin() throws Exception {
-        // Create POST and PUT requests to allow joining room and trigger socket
-        String REST_ENDPOINTS = "http://localhost:" + port + "/api/v1/rooms";
+        // Set up a room with a single user (the host)
+        baseRestEndpoint = "http://localhost:" + port + "/api/v1/rooms";
 
         UserDto host = new UserDto();
         host.setNickname("host");
@@ -73,18 +73,19 @@ public class RoomSocketTests {
 
         // Create room first
         HttpEntity<CreateRoomRequest> createEntity = new HttpEntity<>(createRequest);
-        RoomDto response = template.postForObject(REST_ENDPOINTS, createEntity, RoomDto.class);
+        RoomDto response = template.postForObject(baseRestEndpoint, createEntity, RoomDto.class);
 
         assertNotNull(response);
+        roomId = response.getRoomId();
 
         // Next, set up the socket connection and subscription
         // BlockingQueue will hold the responses from the socket subscribe endpoint
-        BlockingQueue<RoomDto> blockingQueue = new ArrayBlockingQueue<>(1);
+        blockingQueue = new ArrayBlockingQueue<>(1);
 
         // Connect to the socket endpoint
         StompSession session = stompClient
                 .connect(CONNECT_ENDPOINT, new WebSocketHttpHeaders(), new StompSessionHandlerAdapter() {}, this.port)
-                .get(5, SECONDS);
+                .get(3, SECONDS);
 
         // Add socket messages to BlockingQueue so we can verify expected behavior
         session.subscribe(String.format(SUBSCRIBE_ENDPOINT, response.getRoomId()), new StompFrameHandler() {
@@ -98,19 +99,22 @@ public class RoomSocketTests {
                 blockingQueue.add((RoomDto) payload);
             }
         });
+    }
 
-        // Next, join the room, which should trigger a socket message to be sent
+    @Test
+    public void socketReceivesMessageOnJoin() throws Exception {
+        // Join the room, which should trigger a socket message to be sent
         UserDto newUser = new UserDto();
         newUser.setNickname("test");
         JoinRoomRequest joinRequest = new JoinRoomRequest();
-        joinRequest.setRoomId(response.getRoomId());
+        joinRequest.setRoomId(roomId);
         joinRequest.setUser(newUser);
 
         HttpEntity<JoinRoomRequest> joinEntity = new HttpEntity<>(joinRequest);
-        RoomDto expected = template.exchange(REST_ENDPOINTS, HttpMethod.PUT, joinEntity, RoomDto.class).getBody();
+        RoomDto expected = template.exchange(baseRestEndpoint, HttpMethod.PUT, joinEntity, RoomDto.class).getBody();
 
-        // Finally, verify the socket message we received is as we'd expect
-        RoomDto actual = blockingQueue.poll(5, SECONDS);
+        // Verify the socket message we received is as we'd expect
+        RoomDto actual = blockingQueue.poll(3, SECONDS);
         assertNotNull(expected);
         assertNotNull(actual);
         assertEquals(expected.getRoomId(), actual.getRoomId());
@@ -119,8 +123,40 @@ public class RoomSocketTests {
     }
 
     @Test
-    public void socketReceivesMessageOnHostChange() {
+    public void socketReceivesMessageOnHostChange() throws Exception {
+        // A second user joins the room
+        UserDto newUser = new UserDto();
+        newUser.setNickname("test");
+        JoinRoomRequest joinRequest = new JoinRoomRequest();
+        joinRequest.setRoomId(roomId);
+        joinRequest.setUser(newUser);
 
+        HttpEntity<JoinRoomRequest> joinEntity = new HttpEntity<>(joinRequest);
+        RoomDto expected = template.exchange(baseRestEndpoint, HttpMethod.PUT, joinEntity, RoomDto.class).getBody();
+
+        // Socket message is sent and is as expected
+        RoomDto actual = blockingQueue.poll(3, SECONDS);
+        assertNotNull(expected);
+        assertNotNull(actual);
+        assertEquals(expected.getRoomId(), actual.getRoomId());
+        assertEquals(expected.getHost(), actual.getHost());
+        assertEquals(expected.getUsers(), actual.getUsers());
+
+        // A host change request is sent
+        UpdateHostRequest updateRequest = new UpdateHostRequest();
+        updateRequest.setRoomId(roomId);
+        updateRequest.setInitiator(expected.getHost());
+        updateRequest.setNewHost(newUser);
+
+        HttpEntity<UpdateHostRequest> updateEntity = new HttpEntity<>(updateRequest);
+        expected = template.exchange(baseRestEndpoint, HttpMethod.PUT, joinEntity, RoomDto.class).getBody();
+
+        // Verify that the socket receives a message with the updated host
+        actual = blockingQueue.poll(3, SECONDS);
+        assertNotNull(expected);
+        assertNotNull(actual);
+        assertEquals(newUser, actual.getHost());
+        assertEquals(expected.getUsers(), actual.getUsers());
     }
 
 }

--- a/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
+++ b/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
@@ -144,12 +144,12 @@ public class RoomSocketTests {
 
         // A host change request is sent
         UpdateHostRequest updateRequest = new UpdateHostRequest();
-        updateRequest.setRoomId(roomId);
         updateRequest.setInitiator(expected.getHost());
         updateRequest.setNewHost(newUser);
 
         HttpEntity<UpdateHostRequest> updateEntity = new HttpEntity<>(updateRequest);
-        expected = template.exchange(baseRestEndpoint + "/host", HttpMethod.PUT, updateEntity, RoomDto.class).getBody();
+        String updateHostEndpoint = String.format("%s/%s/host", baseRestEndpoint, roomId);
+        expected = template.exchange(updateHostEndpoint, HttpMethod.PUT, updateEntity, RoomDto.class).getBody();
 
         // Verify that the socket receives a message with the updated host
         actual = blockingQueue.poll(3, SECONDS);


### PR DESCRIPTION
### List of Changes:

* Add PUT endpoint for changing room host
* Create new error type for invalid permissions
* Change room's set of users to list of users
* Add tests for new endpoint

### Notes:

* The set of users was changed to a list because sets don't have a get method, and we need that to ensure our objects are equal on both an application level and database level
* A new PUT request in Postman has been added for changing room hosts
* This PR has a lot of lines changed, but probably more than 75% of that is tests

