### PR TITLE
Show difficulty settings on frontend

### DIFF
--- a/frontend/src/api/Difficulty.ts
+++ b/frontend/src/api/Difficulty.ts
@@ -1,4 +1,5 @@
 enum Difficulty {
+  Random = 'RANDOM',
   Easy = 'EASY',
   Medium = 'MEDIUM',
   Hard = 'HARD',

--- a/frontend/src/api/Difficulty.ts
+++ b/frontend/src/api/Difficulty.ts
@@ -1,7 +1,7 @@
 enum Difficulty {
-  EASY = 'EASY',
-  MEDIUM = 'MEDIUM',
-  HARD = 'HARD',
+  Easy = 'EASY',
+  Medium = 'MEDIUM',
+  Hard = 'HARD',
 }
 
 export default Difficulty;

--- a/frontend/src/api/Difficulty.ts
+++ b/frontend/src/api/Difficulty.ts
@@ -1,0 +1,7 @@
+enum Difficulty {
+  EASY = 'EASY',
+  MEDIUM = 'MEDIUM',
+  HARD = 'HARD',
+}
+
+export default Difficulty;

--- a/frontend/src/api/Room.ts
+++ b/frontend/src/api/Room.ts
@@ -17,11 +17,17 @@ export type JoinRoomParams = {
   user: User,
 };
 
+export type UpdateSettingsParams = {
+  initiator: User,
+  difficulty: string,
+}
+
 const basePath = '/api/v1/rooms';
 const routes = {
   createRoom: `${basePath}/`,
   joinRoom: `${basePath}/`,
   getRoom: `${basePath}/`,
+  updateRoomSettings: (roomId: string) => `${basePath}/${roomId}/settings`,
 };
 
 export const createRoom = (roomParams: CreateRoomParams):
@@ -40,6 +46,13 @@ export const joinRoom = (roomParams: JoinRoomParams):
 
 export const getRoom = (roomId: string):
   Promise<Room> => axios.get<Room>(`${routes.getRoom}?roomId=${roomId}`)
+  .then((res) => res.data)
+  .catch((err) => {
+    throw axiosErrorHandler(err);
+  });
+
+export const updateRoomSettings = (roomId: string, roomParams: UpdateSettingsParams):
+  Promise<Room> => axios.put<Room>(routes.updateRoomSettings(roomId), roomParams)
   .then((res) => res.data)
   .catch((err) => {
     throw axiosErrorHandler(err);

--- a/frontend/src/api/Room.ts
+++ b/frontend/src/api/Room.ts
@@ -7,7 +7,7 @@ export type Room = {
   roomId: string;
   host: User;
   users: [User],
-  difficulty: Difficulty | null,
+  difficulty: Difficulty,
 };
 
 export type CreateRoomParams = {
@@ -21,7 +21,7 @@ export type JoinRoomParams = {
 
 export type UpdateSettingsParams = {
   initiator: User,
-  difficulty: Difficulty | null,
+  difficulty: Difficulty,
 }
 
 export type ChangeHostParams = {

--- a/frontend/src/api/Room.ts
+++ b/frontend/src/api/Room.ts
@@ -1,11 +1,13 @@
 import axios from 'axios';
 import { axiosErrorHandler } from './Error';
 import { User } from './User';
+import Difficulty from './Difficulty';
 
 export type Room = {
   roomId: string;
   host: User;
   users: [User],
+  difficulty: Difficulty | null,
 };
 
 export type CreateRoomParams = {
@@ -19,7 +21,7 @@ export type JoinRoomParams = {
 
 export type UpdateSettingsParams = {
   initiator: User,
-  difficulty: string,
+  difficulty: Difficulty | null,
 }
 
 const basePath = '/api/v1/rooms';

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -28,6 +28,15 @@ export const PrimaryButton = styled(DefaultButton)<any>`
   height: ${({ height }) => height || '8vw'};
   min-width: 280px;
   min-height: 70px;
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.colors.gray};
+
+    &:hover {
+      cursor: default;
+      box-shadow: 0 1px 8px rgba(0, 0, 0, 0.24);
+    }
+  }
 `;
 
 export const TextButton = styled.button<ThemeType>`

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -50,6 +50,7 @@ type DifficultyProps = {
 export const DifficultyButton = styled(DefaultButton)<DifficultyProps>`  
   color: ${({ theme, active }) => (active ? theme.colors.white : theme.colors.font)};
   background-color: ${({ theme, active }) => (active ? theme.colors.blue : theme.colors.white)};
+  padding: 8px 16px;
   
   &:hover {
     ${({ theme, enabled }) => enabled && `

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -41,3 +41,17 @@ export const TextButton = styled.button<ThemeType>`
     outline: none;
   }
 `;
+
+type DifficultyProps = {
+  active: boolean,
+}
+
+export const DifficultyButton = styled(DefaultButton)<DifficultyProps>`  
+  color: ${({ theme, active }) => (active ? theme.colors.white : theme.colors.font)};
+  background-color: ${({ theme, active }) => (active ? theme.colors.blue : theme.colors.white)};
+  
+  &:hover {
+    color: ${({ theme }) => theme.colors.white};
+    background-color: ${({ theme }) => theme.colors.blue};
+  }
+`;

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -44,6 +44,7 @@ export const TextButton = styled.button<ThemeType>`
 
 type DifficultyProps = {
   active: boolean,
+  enabled: boolean,
 }
 
 export const DifficultyButton = styled(DefaultButton)<DifficultyProps>`  
@@ -51,7 +52,11 @@ export const DifficultyButton = styled(DefaultButton)<DifficultyProps>`
   background-color: ${({ theme, active }) => (active ? theme.colors.blue : theme.colors.white)};
   
   &:hover {
-    color: ${({ theme }) => theme.colors.white};
-    background-color: ${({ theme }) => theme.colors.blue};
+    ${({ theme, enabled }) => enabled && `
+      color: ${theme.colors.white};
+      background-color: ${theme.colors.blue};
+    `};
+    
+    cursor: ${({ enabled }) => (enabled ? 'pointer' : 'default')};
   }
 `;

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -12,6 +12,10 @@ export const LargeText = styled.h3`
   font-size: ${({ theme }) => theme.fontSize.xLarge};
 `;
 
+export const MediumText = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.xMediumLarge};
+`;
+
 export const LandingHeaderText = styled.h1`
   font-size: ${({ theme }) => theme.fontSize.xxLarge};
 `;

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -86,7 +86,7 @@ function LobbyPage() {
   };
 
   /**
-   * Update the difficulty setting of the room (EASY, MEDIUM, HARD, or none)
+   * Update the difficulty setting of the room (EASY, MEDIUM, HARD, or RANDOM)
    */
   const updateDifficultySetting = (key: string) => {
     if (currentUser?.nickname === host?.nickname && !loading) {

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -229,7 +229,7 @@ function LobbyPage() {
       <br />
 
       {currentUser?.nickname === host?.nickname
-        ? <PrimaryButton onClick={handleStartGame}> Start Game </PrimaryButton>
+        ? <PrimaryButton onClick={handleStartGame} disabled={loading}>Start Game</PrimaryButton>
         : <MediumText>Waiting for the host to start the game...</MediumText>}
     </div>
   );

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -192,7 +192,8 @@ function LobbyPage() {
       { loading ? <Loading /> : null }
 
       <div>
-        { // Show list of users in the room
+        {
+          // Show list of users in the room
           users?.map((user) => (
             <PlayerCard
               user={user}
@@ -218,6 +219,8 @@ function LobbyPage() {
           onClick={() => updateDifficultySetting(key)}
           active={difficulty === Difficulty[key as keyof typeof Difficulty]}
           enabled={currentUser?.nickname === host?.nickname}
+          title={currentUser?.nickname === host?.nickname
+            ? 'Only the host can change these settings' : undefined}
         >
           {key}
         </DifficultyButton>

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import { Message } from 'stompjs';
 import ErrorMessage from '../components/core/Error';
-import { LargeText, UserNicknameText } from '../components/core/Text';
+import { LargeText, MediumText, UserNicknameText } from '../components/core/Text';
 import { connect, routes, subscribe } from '../api/Socket';
 import { getRoom, Room, updateRoomSettings } from '../api/Room';
 import { User } from '../api/User';
@@ -159,6 +159,7 @@ function LobbyPage() {
         }
       </div>
 
+      <MediumText>Difficulty Settings</MediumText>
       {Object.keys(Difficulty).map((key) => (
         <DifficultyButton
           onClick={() => updateDifficultySetting(key)}

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -7,6 +7,8 @@ import { connect, routes, subscribe } from '../api/Socket';
 import { getRoom, Room } from '../api/Room';
 import { User } from '../api/User';
 import { checkLocationState, isValidRoomId } from '../util/Utility';
+import Difficulty from '../api/Difficulty';
+import {DifficultyButton} from '../components/core/Button';
 
 type LobbyPageLocation = {
   user: User,
@@ -25,6 +27,7 @@ function LobbyPage() {
   const [host, setHost] = useState<User | null>(null);
   const [users, setUsers] = useState<User[] | null>(null);
   const [currentRoomId, setRoomId] = useState('');
+  const [difficulty, setDifficulty] = useState<Difficulty | null>(null);
 
   // Hold error text.
   const [error, setError] = useState('');
@@ -39,6 +42,7 @@ function LobbyPage() {
     setHost(room.host);
     setUsers(room.users);
     setRoomId(room.roomId);
+    setDifficulty(room.difficulty);
   };
 
   const deleteUser = (user: User) => {
@@ -124,6 +128,10 @@ function LobbyPage() {
           ))
         }
       </div>
+      { currentUser?.nickname === host?.nickname ? (
+        // Object.keys(Difficulty).map(key => MyEnum[key])
+        <DifficultyButton active={false} />
+      ) : null }
     </div>
   );
 }

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -222,6 +222,7 @@ function LobbyPage() {
           {key}
         </DifficultyButton>
       ))}
+      <br />
 
       {currentUser?.nickname === host?.nickname
         ? <PrimaryButton onClick={handleStartGame}> Start Game </PrimaryButton>

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -220,7 +220,7 @@ function LobbyPage() {
           onClick={() => updateDifficultySetting(key)}
           active={difficulty === Difficulty[key as keyof typeof Difficulty]}
           enabled={currentUser?.nickname === host?.nickname}
-          title={currentUser?.nickname === host?.nickname
+          title={currentUser?.nickname !== host?.nickname
             ? 'Only the host can change these settings' : undefined}
         >
           {key}

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -90,13 +90,12 @@ function LobbyPage() {
    */
   const updateDifficultySetting = (key: string) => {
     if (currentUser?.nickname === host?.nickname && !loading) {
-      setLoading(true);
-      let newDifficulty: Difficulty | null = Difficulty[key as keyof typeof Difficulty];
+      const oldDifficulty = difficulty;
+      const newDifficulty = Difficulty[key as keyof typeof Difficulty];
 
-      // Set new difficulty to none if previous setting was toggled off
-      if (newDifficulty === difficulty) {
-        newDifficulty = null;
-      }
+      setLoading(true);
+      // Preemptively set new difficulty value
+      setDifficulty(newDifficulty);
 
       const newSettings = {
         initiator: currentUser!,
@@ -108,6 +107,8 @@ function LobbyPage() {
         .catch((err) => {
           setLoading(false);
           setError(err.message);
+          // Set difficulty back to original if REST call failed
+          setDifficulty(oldDifficulty);
         });
     }
   };

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -8,7 +8,7 @@ import { getRoom, Room } from '../api/Room';
 import { User } from '../api/User';
 import { checkLocationState, isValidRoomId } from '../util/Utility';
 import Difficulty from '../api/Difficulty';
-import {DifficultyButton} from '../components/core/Button';
+import { DifficultyButton } from '../components/core/Button';
 
 type LobbyPageLocation = {
   user: User,
@@ -128,10 +128,15 @@ function LobbyPage() {
           ))
         }
       </div>
-      { currentUser?.nickname === host?.nickname ? (
-        // Object.keys(Difficulty).map(key => MyEnum[key])
-        <DifficultyButton active={false} />
-      ) : null }
+
+      {Object.keys(Difficulty).map((key) => (
+        <DifficultyButton
+          active={difficulty === Difficulty[key as keyof typeof Difficulty]}
+          enabled={currentUser?.nickname === host?.nickname}
+        >
+          {key}
+        </DifficultyButton>
+      ))}
     </div>
   );
 }

--- a/src/main/java/com/rocketden/main/model/ProblemDifficulty.java
+++ b/src/main/java/com/rocketden/main/model/ProblemDifficulty.java
@@ -5,7 +5,7 @@ import com.rocketden.main.exception.RoomError;
 import com.rocketden.main.exception.api.ApiException;
 
 public enum ProblemDifficulty {
-    EASY, MEDIUM, HARD;
+    EASY, MEDIUM, HARD, RANDOM;
 
     // Convert a matching string (ignoring case) to enum object
     @JsonCreator

--- a/src/main/java/com/rocketden/main/model/Room.java
+++ b/src/main/java/com/rocketden/main/model/Room.java
@@ -48,7 +48,7 @@ public class Room {
     private List<User> users = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
-    private ProblemDifficulty difficulty;
+    private ProblemDifficulty difficulty = ProblemDifficulty.RANDOM;
 
     public void addUser(User user) {
         users.add(user);

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -145,8 +145,10 @@ public class RoomService {
             throw new ApiException(RoomError.INVALID_PERMISSIONS);
         }
 
-        // Set new difficulty value
-        room.setDifficulty(request.getDifficulty());
+        // Set new difficulty value if not null
+        if (request.getDifficulty() != null) {
+            room.setDifficulty(request.getDifficulty());
+        }
         repository.save(room);
 
         RoomDto roomDto = RoomMapper.toDto(room);

--- a/src/test/java/com/rocketden/main/api/RoomTests.java
+++ b/src/test/java/com/rocketden/main/api/RoomTests.java
@@ -502,6 +502,7 @@ public class RoomTests {
         String jsonResponse = result.getResponse().getContentAsString();
         room = Utility.toObject(jsonResponse, RoomDto.class);
 
+        // Difficulty remains unchanged from default
         assertEquals(ProblemDifficulty.RANDOM, room.getDifficulty());
     }
 

--- a/src/test/java/com/rocketden/main/api/RoomTests.java
+++ b/src/test/java/com/rocketden/main/api/RoomTests.java
@@ -122,7 +122,7 @@ public class RoomTests {
 
         assertEquals(expected.getHost(), actual.getHost());
         assertEquals(expected.getUsers(), actual.getUsers());
-        assertNull(actual.getDifficulty());
+        assertEquals(ProblemDifficulty.RANDOM, actual.getDifficulty());
 
         // Send GET request to validate that room exists
         String roomId = actual.getRoomId();
@@ -139,7 +139,7 @@ public class RoomTests {
         assertEquals(expected.getRoomId(), actualGet.getRoomId());
         assertEquals(expected.getHost(), actualGet.getHost());
         assertEquals(expected.getUsers(), actualGet.getUsers());
-        assertNull(actual.getDifficulty());
+        assertEquals(ProblemDifficulty.RANDOM, actual.getDifficulty());
     }
 
     @Test
@@ -454,6 +454,7 @@ public class RoomTests {
         host.setNickname("host");
 
         RoomDto room = setUpRoomWithOneUser(host);
+        assertEquals(ProblemDifficulty.RANDOM, room.getDifficulty());
 
         UpdateSettingsRequest updateRequest = new UpdateSettingsRequest();
         updateRequest.setInitiator(host);
@@ -501,7 +502,7 @@ public class RoomTests {
         String jsonResponse = result.getResponse().getContentAsString();
         room = Utility.toObject(jsonResponse, RoomDto.class);
 
-        assertNull(room.getDifficulty());
+        assertEquals(ProblemDifficulty.RANDOM, room.getDifficulty());
     }
 
     @Test

--- a/src/test/java/com/rocketden/main/mapper/RoomMapperTests.java
+++ b/src/test/java/com/rocketden/main/mapper/RoomMapperTests.java
@@ -28,6 +28,7 @@ public class RoomMapperTests {
 
         Room room = new Room();
         room.setRoomId("012345");
+        room.setDifficulty(ProblemDifficulty.MEDIUM);
         room.setHost(host);
 
         room.addUser(host);

--- a/src/test/java/com/rocketden/main/mapper/RoomMapperTests.java
+++ b/src/test/java/com/rocketden/main/mapper/RoomMapperTests.java
@@ -3,6 +3,7 @@ package com.rocketden.main.mapper;
 import com.rocketden.main.dto.room.RoomDto;
 import com.rocketden.main.dto.room.RoomMapper;
 import com.rocketden.main.dto.user.UserMapper;
+import com.rocketden.main.model.ProblemDifficulty;
 import com.rocketden.main.model.Room;
 import com.rocketden.main.model.User;
 

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -64,7 +64,7 @@ public class RoomServiceTests {
         verify(repository).save(Mockito.any(Room.class));
         assertEquals("012345", response.getRoomId());
         assertEquals(user, response.getHost());
-        assertNull(response.getDifficulty());
+        assertEquals(ProblemDifficulty.RANDOM, response.getDifficulty());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class RoomServiceTests {
         assertEquals(roomId, response.getRoomId());
         assertEquals(2, response.getUsers().size());
         assertTrue(response.getUsers().contains(request.getUser()));
-        assertNull(response.getDifficulty());
+        assertEquals(ProblemDifficulty.RANDOM, response.getDifficulty());
 
         verify(template).convertAndSend(
                  eq(String.format(BaseRestController.BASE_SOCKET_URL + "/%s/subscribe-user", response.getRoomId())),


### PR DESCRIPTION
### List of Changes:

* Show difficulty setting on lobby page
* Allow host to set the difficulty

### Notes:

* Working with [string enums](https://www.typescriptlang.org/docs/handbook/enums.html#string-enums) in TypeScript is kind of weird
* See [here](https://stackoverflow.com/questions/35760096/typescript-enum-from-json-string) for converting the axios difficulty responses into the enum values
* See [here](https://stackoverflow.com/questions/36316326/typescript-ts7015-error-when-accessing-an-enum-using-a-string-type-parameter) for the need for `keyof typeof` to index the enum

### Screencast and Images:

[Short demo](https://www.loom.com/share/56126f54073b4749a76b3fd90a2b0776)
