### PR TITLE
Allow users to choose coding language

### DIFF
--- a/frontend/config-overrides.js
+++ b/frontend/config-overrides.js
@@ -1,0 +1,6 @@
+const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+
+module.exports = function override(config, _) {
+  config.plugins.push(new MonacoWebpackPlugin());
+  return config;
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8573,9 +8573,29 @@
       }
     },
     "monaco-editor": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.20.0.tgz",
-      "integrity": "sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ=="
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.21.2.tgz",
+      "integrity": "sha512-jS51RLuzMaoJpYbu7F6TPuWpnWTLD4kjRW0+AZzcryvbxrTwhNy1KC9yboyKpgMTahpUbDUsuQULoo0GV1EPqg=="
+    },
+    "monaco-editor-webpack-plugin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-2.0.0.tgz",
+      "integrity": "sha512-z3nUGhnNis8eHcPepqrxyt3XwrnHD76E4KwV2ozWlBwYM6B3R5YYqzy40ECfJWqRFcwT4DhaLYaXOk5ym4MZhA==",
+      "requires": {
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        }
+      }
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -8680,9 +8700,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-gyp-build": {
       "version": "3.7.0",
@@ -10590,6 +10610,23 @@
         "whatwg-fetch": "^3.0.0"
       }
     },
+    "react-app-rewired": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.6.tgz",
+      "integrity": "sha512-06flj0kK5tf/RN4naRv/sn6j3sQd7rsURoRLKLpffXDzJeNiAaTNic+0I8Basojy5WDwREkTqrMLewSAjcb13w==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",
@@ -11732,11 +11769,11 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10614,7 +10614,6 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.6.tgz",
       "integrity": "sha512-06flj0kK5tf/RN4naRv/sn6j3sQd7rsURoRLKLpffXDzJeNiAaTNic+0I8Basojy5WDwREkTqrMLewSAjcb13w==",
-      "dev": true,
       "requires": {
         "semver": "^5.6.0"
       },
@@ -10622,8 +10621,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10614,6 +10614,7 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.6.tgz",
       "integrity": "sha512-06flj0kK5tf/RN4naRv/sn6j3sQd7rsURoRLKLpffXDzJeNiAaTNic+0I8Basojy5WDwREkTqrMLewSAjcb13w==",
+      "dev": true,
       "requires": {
         "semver": "^5.6.0"
       },
@@ -10621,7 +10622,8 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,8 @@
     "@types/stompjs": "^2.3.4",
     "@types/styled-components": "^5.1.2",
     "axios": "^0.20.0",
+    "monaco-editor": "^0.21.2",
+    "monaco-editor-webpack-plugin": "^2.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-monaco-editor": "^0.40.0",
@@ -37,13 +39,14 @@
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",
-    "eslint-plugin-react-hooks": "^2.5.1"
+    "eslint-plugin-react-hooks": "^2.5.1",
+    "react-app-rewired": "^2.1.6"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test",
+    "eject": "react-app-rewired eject"
   },
   "proxy": "http://localhost:8080",
   "eslintConfig": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,6 @@
     "monaco-editor": "^0.21.2",
     "monaco-editor-webpack-plugin": "^2.0.0",
     "react": "^16.13.1",
-    "react-app-rewired": "^2.1.6",
     "react-dom": "^16.13.1",
     "react-monaco-editor": "^0.40.0",
     "react-router-dom": "^5.2.0",
@@ -40,13 +39,14 @@
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",
-    "eslint-plugin-react-hooks": "^2.5.1"
+    "eslint-plugin-react-hooks": "^2.5.1",
+    "react-app-rewired": "^2.1.6"
   },
   "scripts": {
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
-    "test": "react-app-rewired test",
-    "eject": "react-app-rewired eject"
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
   },
   "proxy": "http://localhost:8080",
   "eslintConfig": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "monaco-editor": "^0.21.2",
     "monaco-editor-webpack-plugin": "^2.0.0",
     "react": "^16.13.1",
+    "react-app-rewired": "^2.1.6",
     "react-dom": "^16.13.1",
     "react-monaco-editor": "^0.40.0",
     "react-router-dom": "^5.2.0",
@@ -39,8 +40,7 @@
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",
-    "eslint-plugin-react-hooks": "^2.5.1",
-    "react-app-rewired": "^2.1.6"
+    "eslint-plugin-react-hooks": "^2.5.1"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/frontend/src/components/core/Editor.tsx
+++ b/frontend/src/components/core/Editor.tsx
@@ -1,11 +1,19 @@
-import React from 'react';
-import MonacoEditor, { MonacoEditorProps } from 'react-monaco-editor';
+import React, { useState } from 'react';
+import MonacoEditor from 'react-monaco-editor';
+import styled from 'styled-components';
 
-export const languages = {
+type LanguageType = {
+  [key: string]: {
+    name: string,
+    defaultCode: string,
+  }
+};
+
+export const languages: LanguageType = {
   java: {
     name: 'Java',
     defaultCode:
-      'public class Solution {\n\n'
+      'public class Solution {\n'
       + '    public static void main(String[] args) {\n'
       + '        \n'
       + '    }\n'
@@ -37,8 +45,14 @@ export const languages = {
   },
 };
 
+const Content = styled.div`
+  height: 100%;
+`;
+
 // This function refreshes the width of Monaco editor upon change in container size
-function ResizableMonacoEditor(props: MonacoEditorProps) {
+function ResizableMonacoEditor() {
+  const [codeLanguage, setCodeLanguage] = useState('java');
+
   const handleEditorDidMount = (editor: any) => {
     window.addEventListener('resize', () => {
       editor.layout();
@@ -49,10 +63,24 @@ function ResizableMonacoEditor(props: MonacoEditorProps) {
   };
 
   return (
-    <MonacoEditor
-      {...props}
-      editorDidMount={handleEditorDidMount}
-    />
+    <Content>
+      <select
+        onChange={(e) => setCodeLanguage(e.target.value)}
+        value={codeLanguage}
+      >
+        {
+          Object.keys(languages).map((language) => (
+            <option value={language}>{languages[language].name}</option>
+          ))
+        }
+      </select>
+      <MonacoEditor
+        height="100%"
+        editorDidMount={handleEditorDidMount}
+        language={codeLanguage}
+        defaultValue={languages[codeLanguage].defaultCode}
+      />
+    </Content>
   );
 }
 

--- a/frontend/src/components/core/Editor.tsx
+++ b/frontend/src/components/core/Editor.tsx
@@ -77,7 +77,7 @@ function ResizableMonacoEditor() {
       >
         {
           Object.keys(languages).map((language) => (
-            <option value={language}>{languages[language].name}</option>
+            <option key={language} value={language}>{languages[language].name}</option>
           ))
         }
       </select>

--- a/frontend/src/components/core/Editor.tsx
+++ b/frontend/src/components/core/Editor.tsx
@@ -1,6 +1,42 @@
 import React from 'react';
 import MonacoEditor, { MonacoEditorProps } from 'react-monaco-editor';
 
+export const languages = {
+  java: {
+    name: 'Java',
+    defaultCode:
+      'public class Solution {\n\n'
+      + '    public static void main(String[] args) {\n'
+      + '        \n'
+      + '    }\n'
+      + '}\n',
+  },
+  python: {
+    name: 'Python',
+    defaultCode:
+      'def solution():\n'
+      + '    \n',
+  },
+  javascript: {
+    name: 'JavaScript',
+    defaultCode:
+      'function solution() {\n'
+      + '    \n'
+      + '}\n',
+  },
+  csharp: {
+    name: 'C#',
+    defaultCode:
+      'using System;\n\n'
+      + 'public class Solution\n{\n'
+      + '    public static void Main()\n'
+      + '    {\n'
+      + '        \n'
+      + '    }\n'
+      + '}\n',
+  },
+};
+
 // This function refreshes the width of Monaco editor upon change in container size
 function ResizableMonacoEditor(props: MonacoEditorProps) {
   const handleEditorDidMount = (editor: any) => {

--- a/frontend/src/components/core/Editor.tsx
+++ b/frontend/src/components/core/Editor.tsx
@@ -52,8 +52,10 @@ const Content = styled.div`
 // This function refreshes the width of Monaco editor upon change in container size
 function ResizableMonacoEditor() {
   const [codeLanguage, setCodeLanguage] = useState('java');
+  const [codeEditor, setCodeEditor] = useState<any>(null);
 
   const handleEditorDidMount = (editor: any) => {
+    setCodeEditor(editor);
     window.addEventListener('resize', () => {
       editor.layout();
     });
@@ -62,10 +64,15 @@ function ResizableMonacoEditor() {
     });
   };
 
+  const handleLanguageChange = (language: string) => {
+    codeEditor!.setValue(languages[language].defaultCode);
+    setCodeLanguage(language);
+  };
+
   return (
     <Content>
       <select
-        onChange={(e) => setCodeLanguage(e.target.value)}
+        onChange={(e) => handleLanguageChange(e.target.value)}
         value={codeLanguage}
       >
         {

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import SplitterLayout from 'react-splitter-layout';
-import Editor, {languages} from '../components/core/Editor';
+import Editor from '../components/core/Editor';
 import { ErrorResponse } from '../api/Error';
 import { Problem, getProblems } from '../api/Problem';
 import { Room } from '../api/Room';
@@ -22,8 +22,6 @@ function GamePage() {
   const [room, setRoom] = useState<Room | null>(null);
   const [problems, setProblems] = useState<Problem[]>([]);
   const [error, setError] = useState<string>('');
-
-  const [codeLanguage, setCodeLanguage] = useState('java');
 
   // Called every time location changes
   useEffect(() => {
@@ -71,16 +69,7 @@ function GamePage() {
             {error ? <ErrorMessage message={error} /> : null}
           </Panel>
           <Panel>
-            <select
-              onChange={(e) => setCodeLanguage(e.target.value)}
-              value={codeLanguage}
-            >
-              <option value="java">Java</option>
-              <option value="python">Python</option>
-              <option value="javascript">JavaScript</option>
-              <option value="csharp">C#</option>
-            </select>
-            <Editor height="100%" language={codeLanguage} />
+            <Editor />
           </Panel>
         </SplitterLayout>
       </SplitterContainer>

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import SplitterLayout from 'react-splitter-layout';
-import Editor from '../components/core/Editor';
+import Editor, {languages} from '../components/core/Editor';
 import { ErrorResponse } from '../api/Error';
 import { Problem, getProblems } from '../api/Problem';
 import { Room } from '../api/Room';

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -23,6 +23,8 @@ function GamePage() {
   const [problems, setProblems] = useState<Problem[]>([]);
   const [error, setError] = useState<string>('');
 
+  const [codeLanguage, setCodeLanguage] = useState('java');
+
   // Called every time location changes
   useEffect(() => {
     if (checkLocationState(location, 'room')) {
@@ -69,7 +71,16 @@ function GamePage() {
             {error ? <ErrorMessage message={error} /> : null}
           </Panel>
           <Panel>
-            <Editor height="100%" language="javascript" />
+            <select
+              onChange={(e) => setCodeLanguage(e.target.value)}
+              value={codeLanguage}
+            >
+              <option value="java">Java</option>
+              <option value="python">Python</option>
+              <option value="javascript">JavaScript</option>
+              <option value="csharp">C#</option>
+            </select>
+            <Editor height="100%" language={codeLanguage} />
           </Panel>
         </SplitterLayout>
       </SplitterContainer>


### PR DESCRIPTION
### List of Changes:

* Allow users to toggle coding language (Java, Python, JavaScript, C#)
* Enable syntax highlighting 
* Add default code for each language

### Notes:

* [Source](https://github.com/react-monaco-editor/react-monaco-editor#usage-with-create-react-app) behind config file and `react-app-rewired`
* Syntax validation works but IntelliSense and error validation don't seem to be well-documented with the Monaco editor we're using

### Screencast and Images:

![Game page with code editor](https://user-images.githubusercontent.com/24768574/95801405-1a00c400-0caf-11eb-8434-cbc5606bf931.png)
