### PR TITLE
Add new utility generate unique id method.

### DIFF
--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -57,7 +57,7 @@ public class RoomService {
 
         // Add userId if not already present.
         if (user.getUserId() == null) {
-            user.setUserId(utility.generateId(UserService.USER_ID_LENGTH));
+            user.setUserId(utility.generateUniqueId(UserService.USER_ID_LENGTH, Utility.USER_ID_KEY));
         }
 
         // Add the user to the room.
@@ -82,11 +82,11 @@ public class RoomService {
 
         // Create user ID for the host if not already present.
         if (host.getUserId() == null) {
-            host.setUserId(utility.generateId(UserService.USER_ID_LENGTH));
+            host.setUserId(utility.generateUniqueId(UserService.USER_ID_LENGTH, Utility.USER_ID_KEY));
         }
 
         Room room = new Room();
-        room.setRoomId(utility.generateId(ROOM_ID_LENGTH));
+        room.setRoomId(utility.generateUniqueId(RoomService.ROOM_ID_LENGTH, Utility.ROOM_ID_KEY));
         room.setHost(host);
         room.addUser(host);
         repository.save(room);

--- a/src/main/java/com/rocketden/main/service/UserService.java
+++ b/src/main/java/com/rocketden/main/service/UserService.java
@@ -42,7 +42,7 @@ public class UserService {
 
         // If no user ID is present set a new automatically-generated user ID.
         if (request.getUserId() == null) {
-            user.setUserId(utility.generateId(UserService.USER_ID_LENGTH));
+            user.setUserId(utility.generateUniqueId(UserService.USER_ID_LENGTH, Utility.USER_ID_KEY));
         } else {
             user.setUserId(request.getUserId());
         }

--- a/src/main/java/com/rocketden/main/util/Utility.java
+++ b/src/main/java/com/rocketden/main/util/Utility.java
@@ -51,7 +51,7 @@ public class Utility {
     }
 
     // Determine if the id of idType already exists in the database.
-    public boolean idExists(String id, String idType) {
+    private boolean idExists(String id, String idType) {
         switch (idType) {
             case (ROOM_ID_KEY):
                 return roomRepository.findRoomByRoomId(id) != null;

--- a/src/main/java/com/rocketden/main/util/Utility.java
+++ b/src/main/java/com/rocketden/main/util/Utility.java
@@ -35,25 +35,29 @@ public class Utility {
          * Note: This loop could technically run forever, but there are 9^6
          * (531,441) possible combinations, so this works for now (10/20/2020).
          */
-        while (id == null || idExists(id, idType)) {
-            for (int i = 0; i < values.length; i++) {
-                int index = random.nextInt(numbers.length());
-                values[i] = numbers.charAt(index);
+        try {
+            while (id == null || idExists(id, idType)) {
+                for (int i = 0; i < values.length; i++) {
+                    int index = random.nextInt(numbers.length());
+                    values[i] = numbers.charAt(index);
+                }
+                id = new String(values);
             }
-            id = new String(values);
+            return id;
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(e);
         }
-        return id;
     }
 
     // Determine if the id of idType already exists in the database.
     private boolean idExists(String id, String idType) {
-        if (idType.equals(ROOM_ID_KEY)) {
-            return roomRepository.findRoomByRoomId(id) != null;
-        } else if (idType.equals(USER_ID_KEY)) {
-            return userRepository.findUserByUserId(id) != null; 
+        switch (idType) {
+            case (ROOM_ID_KEY):
+                return roomRepository.findRoomByRoomId(id) != null;
+            case (USER_ID_KEY):
+                return userRepository.findUserByUserId(id) != null; 
+            default:
+                throw new IllegalArgumentException(String.format("The provided id type of %s is invalid.", idType));
         }
-        
-        // Return false for case where invalid or not present idType is given.
-        return true;
     }
 }

--- a/src/main/java/com/rocketden/main/util/Utility.java
+++ b/src/main/java/com/rocketden/main/util/Utility.java
@@ -45,12 +45,13 @@ public class Utility {
             }
             return id;
         } catch (IllegalArgumentException e) {
+            // Throw IllegalArgumentException for invalid id type.
             throw new IllegalArgumentException(e);
         }
     }
 
     // Determine if the id of idType already exists in the database.
-    private boolean idExists(String id, String idType) {
+    public boolean idExists(String id, String idType) {
         switch (idType) {
             case (ROOM_ID_KEY):
                 return roomRepository.findRoomByRoomId(id) != null;

--- a/src/main/java/com/rocketden/main/util/Utility.java
+++ b/src/main/java/com/rocketden/main/util/Utility.java
@@ -2,23 +2,58 @@ package com.rocketden.main.util;
 
 import java.util.Random;
 
+import com.rocketden.main.dao.RoomRepository;
+import com.rocketden.main.dao.UserRepository;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class Utility {
 
     private static final Random random = new Random();
+    public static final String ROOM_ID_KEY = "ROOM_ID";
+    public static final String USER_ID_KEY = "USER_ID";
+
+    private final RoomRepository roomRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public Utility(RoomRepository roomRepository, UserRepository userRepository) {
+        this.roomRepository = roomRepository;
+        this.userRepository = userRepository;
+    }
 
     // Generate numeric String with a specific length.
-    public String generateId(int length) {
+    public String generateUniqueId(int length, String idType) {
         String numbers = "1234567890";
         char[] values = new char[length];
-
-        for (int i = 0; i < values.length; i++) {
-            int index = random.nextInt(numbers.length());
-            values[i] = numbers.charAt(index);
+        String id = null;
+        
+        /**
+         * Continue generating new id values until a valid one is provided.
+         * Note: This loop could technically run forever, but there are 9^6
+         * (531,441) possible combinations, so this works for now (10/20/2020).
+         */
+        while (id == null || idExists(id, idType)) {
+            for (int i = 0; i < values.length; i++) {
+                int index = random.nextInt(numbers.length());
+                values[i] = numbers.charAt(index);
+            }
+            id = new String(values);
         }
+        return id;
+    }
 
-        return new String(values);
+    // Determine if the id of idType already exists in the database.
+    private boolean idExists(String id, String idType) {
+        if (idType.equals(ROOM_ID_KEY)) {
+            return roomRepository.findRoomByRoomId(id) != null;
+        } else if (idType.equals(USER_ID_KEY)) {
+            return userRepository.findUserByUserId(id) != null; 
+        }
+        
+        // Return false for case where invalid or not present idType is given.
+        return true;
     }
 }

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -70,12 +70,16 @@ public class RoomServiceTests {
         // Mock generateUniqueId to return a custom room id
         Mockito.doReturn(ROOM_ID).when(utility).generateUniqueId(eq(RoomService.ROOM_ID_LENGTH), eq(Utility.ROOM_ID_KEY));
 
+        // Mock generateUniqueId to return a custom user id
+        Mockito.doReturn(USER_ID).when(utility).generateUniqueId(eq(UserService.USER_ID_LENGTH), eq(Utility.USER_ID_KEY));
+
         // Verify create room request succeeds and returns correct response
         RoomDto response = roomService.createRoom(request);
 
         verify(repository).save(Mockito.any(Room.class));
         assertEquals(ROOM_ID, response.getRoomId());
         assertEquals(user.getNickname(), response.getHost().getNickname());
+        assertEquals(USER_ID, response.getHost().getUserId());
         assertEquals(ProblemDifficulty.RANDOM, response.getDifficulty());
     }
 

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -58,6 +58,7 @@ public class RoomServiceTests {
     private static final String NICKNAME_2 = "rocketrocket";
     private static final String NICKNAME_3 = "rocketandrocket";
     private static final String ROOM_ID = "012345";
+    private static final String USER_ID = "678910";
 
     @Test
     public void createRoomSuccess() {
@@ -86,8 +87,8 @@ public class RoomServiceTests {
         JoinRoomRequest request = new JoinRoomRequest();
         request.setUser(UserMapper.toDto(user));
 
-        // Mock generateUniqueId to return a custom room id
-        Mockito.doReturn(ROOM_ID).when(utility).generateUniqueId(eq(RoomService.ROOM_ID_LENGTH), eq(Utility.ROOM_ID_KEY));
+        // Mock generateUniqueId to return a custom user id
+        Mockito.doReturn(USER_ID).when(utility).generateUniqueId(eq(UserService.USER_ID_LENGTH), eq(Utility.USER_ID_KEY));
 
         Room room = new Room();
         room.setRoomId(ROOM_ID);
@@ -107,7 +108,7 @@ public class RoomServiceTests {
         assertEquals(2, response.getUsers().size());
         assertEquals(host.getNickname(), response.getUsers().get(0).getNickname());
         assertEquals(user.getNickname(), response.getUsers().get(1).getNickname());
-        assertEquals(ROOM_ID, response.getUsers().get(1).getUserId());
+        assertEquals(USER_ID, response.getUsers().get(1).getUserId());
         assertEquals(ProblemDifficulty.RANDOM, response.getDifficulty());
     }
 

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -66,8 +66,8 @@ public class RoomServiceTests {
         CreateRoomRequest request = new CreateRoomRequest();
         request.setHost(user);
         
-        // Mock generateId to return a custom room id
-        Mockito.doReturn(ROOM_ID).when(utility).generateId(eq(RoomService.ROOM_ID_LENGTH));
+        // Mock generateUniqueId to return a custom room id
+        Mockito.doReturn(ROOM_ID).when(utility).generateUniqueId(eq(RoomService.ROOM_ID_LENGTH), eq(Utility.ROOM_ID_KEY));
 
         // Verify create room request succeeds and returns correct response
         RoomDto response = roomService.createRoom(request);
@@ -86,8 +86,8 @@ public class RoomServiceTests {
         JoinRoomRequest request = new JoinRoomRequest();
         request.setUser(UserMapper.toDto(user));
 
-        // Mock generateId to return a custom room id
-        Mockito.doReturn(ROOM_ID).when(utility).generateId(eq(RoomService.ROOM_ID_LENGTH));
+        // Mock generateUniqueId to return a custom room id
+        Mockito.doReturn(ROOM_ID).when(utility).generateUniqueId(eq(RoomService.ROOM_ID_LENGTH), eq(Utility.ROOM_ID_KEY));
 
         Room room = new Room();
         room.setRoomId(ROOM_ID);

--- a/src/test/java/com/rocketden/main/service/UserServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/UserServiceTests.java
@@ -57,7 +57,7 @@ public class UserServiceTests {
         CreateUserRequest request = new CreateUserRequest();
         request.setNickname(NICKNAME);
 
-        Mockito.doReturn(USER_ID).when(utility).generateId(eq(UserService.USER_ID_LENGTH));
+        Mockito.doReturn(USER_ID).when(utility).generateUniqueId(eq(UserService.USER_ID_LENGTH), eq(Utility.USER_ID_KEY));
 
         UserDto response = service.createUser(request);
         verify(repository).save(Mockito.any(User.class));

--- a/src/test/java/com/rocketden/main/util/UtilityTests.java
+++ b/src/test/java/com/rocketden/main/util/UtilityTests.java
@@ -1,19 +1,28 @@
 package com.rocketden.main.util;
 
+import com.rocketden.main.dao.UserRepository;
+import com.rocketden.main.model.User;
 import com.rocketden.main.service.RoomService;
 import com.rocketden.main.service.UserService;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
 
 @SpringBootTest
 public class UtilityTests {
 
     private final Utility utility;
+
+    @Mock
+	private UserRepository userRepository;
 
     @Autowired
     public UtilityTests(Utility utility) {
@@ -44,5 +53,28 @@ public class UtilityTests {
             assertTrue(c >= '0');
             assertTrue(c <= '9');
         }
+    }
+
+    @Test
+    public void generateValidUserIdSecondTime() {
+        /**
+         * Simulate first user ID already existing in the database, and second 
+         * user ID not present in the database.
+         */
+        Mockito.doReturn(new User()).when(userRepository).findUserByUserId(Mockito.any(String.class));
+        String userId = utility.generateUniqueId(UserService.USER_ID_LENGTH, Utility.USER_ID_KEY);
+        verify(userRepository).findUserByUserId(Mockito.any(String.class));
+
+        assertEquals(UserService.USER_ID_LENGTH, userId.length());
+
+        for (char c : userId.toCharArray()) {
+            assertTrue(c >= '0');
+            assertTrue(c <= '9');
+        }
+    }
+
+    @Test
+    public void generateUserIdInvalidType() {
+        assertThrows(IllegalArgumentException.class, () -> utility.generateUniqueId(UserService.USER_ID_LENGTH, "INVALID_KEY"));
     }
 }

--- a/src/test/java/com/rocketden/main/util/UtilityTests.java
+++ b/src/test/java/com/rocketden/main/util/UtilityTests.java
@@ -4,6 +4,7 @@ import com.rocketden.main.service.RoomService;
 import com.rocketden.main.service.UserService;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.Assert.assertEquals;
@@ -12,12 +13,17 @@ import static org.junit.Assert.assertTrue;
 @SpringBootTest
 public class UtilityTests {
 
-    private final Utility utility = new Utility();
+    private final Utility utility;
+
+    @Autowired
+    public UtilityTests(Utility utility) {
+        this.utility = utility;
+    }
 
     @Test
     public void generateValidRoomId() {
         // Verify room ids are generated correctly
-        String roomId = utility.generateId(RoomService.ROOM_ID_LENGTH);
+        String roomId = utility.generateUniqueId(RoomService.ROOM_ID_LENGTH, Utility.ROOM_ID_KEY);
 
         assertEquals(RoomService.ROOM_ID_LENGTH, roomId.length());
 
@@ -30,7 +36,7 @@ public class UtilityTests {
     @Test
     public void generateValidUserId() {
         // Verify user ids are generated correctly
-        String userId = utility.generateId(UserService.USER_ID_LENGTH);
+        String userId = utility.generateUniqueId(UserService.USER_ID_LENGTH, Utility.USER_ID_KEY);
 
         assertEquals(UserService.USER_ID_LENGTH, userId.length());
 

--- a/src/test/java/com/rocketden/main/util/UtilityTests.java
+++ b/src/test/java/com/rocketden/main/util/UtilityTests.java
@@ -13,8 +13,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;

--- a/src/test/java/com/rocketden/main/util/UtilityTests.java
+++ b/src/test/java/com/rocketden/main/util/UtilityTests.java
@@ -1,33 +1,39 @@
 package com.rocketden.main.util;
 
+import com.rocketden.main.dao.RoomRepository;
 import com.rocketden.main.dao.UserRepository;
 import com.rocketden.main.model.User;
 import com.rocketden.main.service.RoomService;
 import com.rocketden.main.service.UserService;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 public class UtilityTests {
 
-    private final Utility utility;
+    @Spy
+    @InjectMocks
+    private Utility utility;
 
     @Mock
-	private UserRepository userRepository;
-
-    @Autowired
-    public UtilityTests(Utility utility) {
-        this.utility = utility;
-    }
+    private UserRepository userRepository;
+    
+    @Mock
+	private RoomRepository roomRepository;
 
     @Test
     public void generateValidRoomId() {
@@ -61,9 +67,12 @@ public class UtilityTests {
          * Simulate first user ID already existing in the database, and second 
          * user ID not present in the database.
          */
-        Mockito.doReturn(new User()).when(userRepository).findUserByUserId(Mockito.any(String.class));
+        User nullUser = null;
+        Mockito.doReturn(new User(), nullUser).when(userRepository).findUserByUserId(Mockito.any(String.class));
         String userId = utility.generateUniqueId(UserService.USER_ID_LENGTH, Utility.USER_ID_KEY);
-        verify(userRepository).findUserByUserId(Mockito.any(String.class));
+
+        // Confirm that the method was indeed called two times.
+        verify(userRepository, times(2)).findUserByUserId(Mockito.any(String.class));
 
         assertEquals(UserService.USER_ID_LENGTH, userId.length());
 


### PR DESCRIPTION
### List of Changes:
- Update the `generateId` method to `generateUniqueId` that takes in the `idType` (`roomId` or `userId`, for now), and continues generating IDs until it finds one that does not exist.
- Update the corresponding tests and method calls throughout the codebase.

### Notes:
- I left a note on the modified method `generateUniqueId` that there is a possibility that this method runs forever, or at least for a very long time. There are `9^6`, or `531,441`, possible combinations, so right now this should not be a problem, but if we reach more users than we will want to change the `userId` generation method (the `roomId` generation method could potentially still stay the same depending on how we handle finished games).
- I am happy to update the `ROOM_ID_KEY` and `USER_ID_KEY` constants to use an enum, I was just more uncertain of how that works / when it's applicable so wanted to implement this simpler version first.
- The `joinRoomSuccess` and the `createRoomSuccess` tests interchanged the `userId` for a `roomId` instead; I fixed that mistake in this PR.
- The first time the test ran, it failed due to the same socket issues; it worked the second time.

### Screencast and Images:
There are no updates to the UI so no screencasts or images are provided.
