### PR TITLE
Update scripts to use react-app-rewired while maintaining quick build speed.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,9 +45,9 @@
     "eslint-plugin-react-hooks": "^2.5.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test",
     "eject": "react-scripts eject"
   },
   "proxy": "http://localhost:8080",

--- a/src/main/java/com/rocketden/main/dto/problem/CreateTestCaseRequest.java
+++ b/src/main/java/com/rocketden/main/dto/problem/CreateTestCaseRequest.java
@@ -9,4 +9,5 @@ public class CreateTestCaseRequest {
     private String input;
     private String output;
     private boolean hidden = false;
+    private String explanation;
 }

--- a/src/main/java/com/rocketden/main/dto/problem/ProblemTestCaseDto.java
+++ b/src/main/java/com/rocketden/main/dto/problem/ProblemTestCaseDto.java
@@ -11,4 +11,5 @@ public class ProblemTestCaseDto {
     private String input;
     private String output;
     private boolean hidden;
+    private String explanation;
 }

--- a/src/main/java/com/rocketden/main/model/problem/ProblemTestCase.java
+++ b/src/main/java/com/rocketden/main/model/problem/ProblemTestCase.java
@@ -35,4 +35,7 @@ public class ProblemTestCase {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "problem_table_id")
     private Problem problem;
+
+    @EqualsAndHashCode.Include
+    private String explanation;
 }

--- a/src/main/java/com/rocketden/main/service/ProblemService.java
+++ b/src/main/java/com/rocketden/main/service/ProblemService.java
@@ -96,6 +96,7 @@ public class ProblemService {
             throw new ApiException(ProblemError.NOT_FOUND);
         }
 
+        // Problem input and output are the two required fields.
         if (request.getInput() == null || request.getOutput() == null) {
             throw new ApiException(ProblemError.EMPTY_FIELD);
         }
@@ -103,7 +104,12 @@ public class ProblemService {
         ProblemTestCase testCase = new ProblemTestCase();
         testCase.setInput(request.getInput());
         testCase.setOutput(request.getOutput());
+
+        // Test case is not hidden by default.
         testCase.setHidden(request.isHidden());
+
+        // Explanation may be null, indicating no explanation is attached.
+        testCase.setExplanation(request.getExplanation());
 
         problem.addTestCase(testCase);
         repository.save(problem);

--- a/src/test/java/com/rocketden/main/entity/ProblemEntityTests.java
+++ b/src/test/java/com/rocketden/main/entity/ProblemEntityTests.java
@@ -16,6 +16,7 @@ public class ProblemEntityTests {
     private static final int ID = 10;
     private static final String INPUT = "[1, 8, 2]";
     private static final String OUTPUT = "[1, 2, 8]";
+    private static final String EXPLANATION = "2 < 8, so those are swapped.";
 
     @Test
     public void problemInitialization() {
@@ -31,6 +32,7 @@ public class ProblemEntityTests {
         Problem problem = new Problem();
         ProblemTestCase testCase = new ProblemTestCase();
 
+        // The function has no restrictions on necessary test case components.
         problem.addTestCase(testCase);
 
         assertEquals(1, problem.getTestCases().size());
@@ -46,19 +48,24 @@ public class ProblemEntityTests {
         testCase.setId(ID);
         testCase.setInput(INPUT);
         testCase.setOutput(OUTPUT);
+        testCase.setExplanation(EXPLANATION);
 
         problem.addTestCase(testCase);
 
         ProblemTestCase caseToRemove = new ProblemTestCase();
         caseToRemove.setInput(INPUT);
         caseToRemove.setOutput(OUTPUT);
+        caseToRemove.setExplanation(EXPLANATION);
         caseToRemove.setHidden(true);
 
         assertFalse(problem.removeTestCase(caseToRemove));
 
         caseToRemove.setId(ID);
         caseToRemove.setHidden(false);
+
+        // Function returns true to remove test case, then false once deleted.
         assertTrue(problem.removeTestCase(caseToRemove));
+        assertFalse(problem.removeTestCase(caseToRemove));
         assertTrue(problem.getTestCases().isEmpty());
     }
 }

--- a/src/test/java/com/rocketden/main/mapper/ProblemMapperTests.java
+++ b/src/test/java/com/rocketden/main/mapper/ProblemMapperTests.java
@@ -22,6 +22,7 @@ public class ProblemMapperTests {
 
     private static final String INPUT = "[1, 8, 2]";
     private static final String OUTPUT = "[1, 2, 8]";
+    private static final String EXPLANATION = "2 < 8, so those are swapped.";
 
     @Test
     public void entityToDto() {
@@ -33,6 +34,7 @@ public class ProblemMapperTests {
         ProblemTestCase testCase = new ProblemTestCase();
         testCase.setInput(INPUT);
         testCase.setOutput(OUTPUT);
+        testCase.setExplanation(EXPLANATION);
         testCase.setHidden(true);
         expected.addTestCase(testCase);
 
@@ -57,11 +59,13 @@ public class ProblemMapperTests {
         expected.setInput(INPUT);
         expected.setOutput(OUTPUT);
         expected.setHidden(false);
+        expected.setExplanation(EXPLANATION);
 
         ProblemTestCaseDto actual = ProblemMapper.toTestCaseDto(expected);
 
         assertEquals(expected.getInput(), actual.getInput());
         assertEquals(expected.getOutput(), actual.getOutput());
         assertEquals(expected.getHidden(), actual.isHidden());
+        assertEquals(expected.getExplanation(), actual.getExplanation());
     }
 }

--- a/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
@@ -20,7 +20,6 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -46,6 +45,7 @@ public class ProblemServiceTests {
 
     private static final String INPUT = "[1, 8, 2]";
     private static final String OUTPUT = "[1, 2, 8]";
+    private static final String EXPLANATION = "2 < 8, so those are swapped.";
 
     @Test
     public void getProblemSuccess() {
@@ -57,6 +57,7 @@ public class ProblemServiceTests {
         ProblemTestCase testCase = new ProblemTestCase();
         testCase.setInput(INPUT);
         testCase.setOutput(OUTPUT);
+        testCase.setExplanation(EXPLANATION);
         expected.addTestCase(testCase);
 
         Mockito.doReturn(expected).when(repository).findProblemByProblemId(expected.getProblemId());
@@ -70,6 +71,7 @@ public class ProblemServiceTests {
 
         assertEquals(expected.getTestCases().get(0).getInput(), response.getTestCases().get(0).getInput());
         assertEquals(expected.getTestCases().get(0).getOutput(), response.getTestCases().get(0).getOutput());
+        assertEquals(expected.getTestCases().get(0).getExplanation(), response.getTestCases().get(0).getExplanation());
     }
 
     @Test
@@ -168,6 +170,7 @@ public class ProblemServiceTests {
         request.setInput(INPUT);
         request.setOutput(OUTPUT);
         request.setHidden(true);
+        request.setExplanation(EXPLANATION);
 
         ProblemTestCaseDto response = problemService.createTestCase(expected.getProblemId(), request);
 
@@ -176,6 +179,7 @@ public class ProblemServiceTests {
         assertEquals(INPUT, response.getInput());
         assertEquals(OUTPUT, response.getOutput());
         assertTrue(response.isHidden());
+        assertEquals(EXPLANATION, response.getExplanation());
 
         // The created test case should be added to this problem
         assertEquals(1, expected.getTestCases().size());


### PR DESCRIPTION
### List of Changes:
- Update scripts to use `react-app-rewired` on start, build, and test.

### Notes:
- This change was originally made in PR #62. Attached to that is a link that explains the [config file changes](https://github.com/react-monaco-editor/react-monaco-editor#usage-with-create-react-app) and the [usage of react-app-rewired](https://github.com/timarney/react-app-rewired).
- I believe this runs faster because I changed the `"test"` script to use `react-app-rewired` as well, whereas before in PR #62 only the `"start"` and `"build"` scripts were updated. However, we'll see if this works on merge and deploy.

### Screencast and Images:
No images or screencasts are used in this PR.
