### PR TITLE
Change remove users to a DELETE endpoint

### DIFF
--- a/frontend/src/api/Room.ts
+++ b/frontend/src/api/Room.ts
@@ -82,10 +82,11 @@ export const changeRoomHost = (roomId: string, roomParams: ChangeHostParams):
   });
 
 export const removeUser = (roomId: string, roomParams: RemoveUserParams):
-  Promise<Room> => axios.delete<Room>(routes.removeUser(roomId), {
-    headers: { 'Content-Type': 'application/json' },
-    data: roomParams,
-  })
+  Promise<Room> => axios({
+  url: routes.removeUser(roomId),
+  method: 'DELETE',
+  data: roomParams,
+})
   .then((res) => res.data)
   .catch((err) => {
     throw axiosErrorHandler(err);

--- a/frontend/src/api/Room.ts
+++ b/frontend/src/api/Room.ts
@@ -43,7 +43,7 @@ const routes = {
   getRoom: (roomId: string) => `${basePath}/${roomId}`,
   updateRoomSettings: (roomId: string) => `${basePath}/${roomId}/settings`,
   changeRoomHost: (roomId: string) => `${basePath}/${roomId}/host`,
-  removeUser: (roomId: string) => `${basePath}/${roomId}/users/remove`,
+  removeUser: (roomId: string) => `${basePath}/${roomId}/users`,
 };
 
 export const createRoom = (roomParams: CreateRoomParams):
@@ -82,7 +82,10 @@ export const changeRoomHost = (roomId: string, roomParams: ChangeHostParams):
   });
 
 export const removeUser = (roomId: string, roomParams: RemoveUserParams):
-  Promise<Room> => axios.put<Room>(routes.removeUser(roomId), roomParams)
+  Promise<Room> => axios.delete<Room>(routes.removeUser(roomId), {
+    headers: { 'Content-Type': 'application/json' },
+    data: roomParams,
+  })
   .then((res) => res.data)
   .catch((err) => {
     throw axiosErrorHandler(err);

--- a/src/main/java/com/rocketden/main/controller/v1/RoomController.java
+++ b/src/main/java/com/rocketden/main/controller/v1/RoomController.java
@@ -11,6 +11,7 @@ import com.rocketden.main.service.RoomService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,7 +44,7 @@ public class RoomController extends BaseRestController {
         return new ResponseEntity<>(service.createRoom(request), HttpStatus.CREATED);
     }
 
-    @PutMapping("/rooms/{roomId}/users/remove")
+    @DeleteMapping("/rooms/{roomId}/users")
     public ResponseEntity<RoomDto> removeUser(@PathVariable String roomId,
                                               @RequestBody RemoveUserRequest request) {
         return new ResponseEntity<>(service.removeUser(roomId, request), HttpStatus.OK);

--- a/src/test/java/com/rocketden/main/api/RoomTests.java
+++ b/src/test/java/com/rocketden/main/api/RoomTests.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -50,7 +51,7 @@ public class RoomTests {
     private static final String POST_ROOM_CREATE = "/api/v1/rooms";
     private static final String PUT_ROOM_HOST = "/api/v1/rooms/%s/host";
     private static final String PUT_ROOM_SETTINGS = "/api/v1/rooms/%s/settings";
-    private static final String REMOVE_USER = "/api/v1/rooms/%s/users/remove";
+    private static final String REMOVE_USER = "/api/v1/rooms/%s/users";
 
     // Predefine user and room attributes.
     private static final String NICKNAME = "rocket";
@@ -566,7 +567,7 @@ public class RoomTests {
         request.setInitiator(host);
         request.setUserToDelete(user);
 
-        MvcResult result = this.mockMvc.perform(put(String.format(REMOVE_USER, room.getRoomId()))
+        MvcResult result = this.mockMvc.perform(delete(String.format(REMOVE_USER, room.getRoomId()))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(UtilityTestMethods.convertObjectToJsonString(request)))
                 .andExpect(status().isOk())
@@ -596,7 +597,7 @@ public class RoomTests {
 
         ApiError ERROR = UserError.NOT_FOUND;
 
-        MvcResult result = this.mockMvc.perform(put(String.format(REMOVE_USER, room.getRoomId()))
+        MvcResult result = this.mockMvc.perform(delete(String.format(REMOVE_USER, room.getRoomId()))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(UtilityTestMethods.convertObjectToJsonString(request)))
                 .andExpect(status().is(ERROR.getStatus().value()))
@@ -626,7 +627,7 @@ public class RoomTests {
 
         ApiError ERROR = RoomError.INVALID_PERMISSIONS;
 
-        MvcResult result = this.mockMvc.perform(put(String.format(REMOVE_USER, room.getRoomId()))
+        MvcResult result = this.mockMvc.perform(delete(String.format(REMOVE_USER, room.getRoomId()))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(UtilityTestMethods.convertObjectToJsonString(request)))
                 .andExpect(status().is(ERROR.getStatus().value()))

--- a/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
+++ b/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
@@ -31,8 +31,10 @@ import java.util.concurrent.BlockingQueue;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = "spring.datasource.type=com.zaxxer.hikari.HikariDataSource")
@@ -329,7 +331,7 @@ public class RoomSocketTests {
         assertNotNull(actual);
 
         assertEquals(expected.getRoomId(), actual.getRoomId());
-        assertEquals(true, actual.isActive());
+        assertTrue(actual.isActive());
     }
 
     @Test
@@ -348,7 +350,7 @@ public class RoomSocketTests {
         assertNotNull(actual);
 
         // Check that the room contains the user
-        assertEquals(true, actual.getUsers().contains(newUser));
+        assertTrue(actual.getUsers().contains(newUser));
 
         RemoveUserRequest removeUserRequest = new RemoveUserRequest();
         removeUserRequest.setInitiator(room.getHost());
@@ -363,6 +365,6 @@ public class RoomSocketTests {
         assertNotNull(actual);
 
         assertEquals(expected.getRoomId(), actual.getRoomId());
-        assertEquals(false, actual.getUsers().contains(newUser));
+        assertFalse(actual.getUsers().contains(newUser));
     }
 }

--- a/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
+++ b/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
@@ -355,8 +355,8 @@ public class RoomSocketTests {
         removeUserRequest.setUserToDelete(newUser);
 
         HttpEntity<RemoveUserRequest> removeUserEntity = new HttpEntity<>(removeUserRequest);
-        String removeUserEndpoint = String.format("%s/%s/users/remove", baseRestEndpoint, room.getRoomId());
-        RoomDto expected = template.exchange(removeUserEndpoint, HttpMethod.PUT, removeUserEntity, RoomDto.class).getBody();
+        String removeUserEndpoint = String.format("%s/%s/users", baseRestEndpoint, room.getRoomId());
+        RoomDto expected = template.exchange(removeUserEndpoint, HttpMethod.DELETE, removeUserEntity, RoomDto.class).getBody();
 
         actual = blockingQueue.poll(5, SECONDS);
         assertNotNull(expected);


### PR DESCRIPTION
### List of Changes:

* Change remove users to a DELETE endpoint
* Update frontend and tests accordingly

### Notes:

* This is to stay consistent with REST guidelines, although to be fair this does introduce including a request body in a DELETE request, which is slightly unusual
* In order to get a DELETE request with a request body using axios, the syntax had to be slightly changed
