### PR TITLE
Fix lobby page bug with back button and reopening tab

### DIFF
--- a/frontend/src/api/Socket.ts
+++ b/frontend/src/api/Socket.ts
@@ -53,7 +53,7 @@ export const connect = (roomId: string, userId: string):
         reject(errorHandler('The socket failed to connect.'));
       });
     } else {
-      reject(errorHandler('The socket is already connected.'));
+      resolve();
     }
   });
 

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -172,7 +172,6 @@ function LobbyPage() {
      */
     const subscribeCallback = (result: Message) => {
       setStateFromRoom(JSON.parse(result.body));
-      console.log(JSON.parse(result.body).host);
     };
 
     connect(roomId, userId).then(() => {
@@ -188,7 +187,6 @@ function LobbyPage() {
 
   // Grab the nickname variable and add the user to the lobby.
   useEffect(() => {
-    console.log('useEffect - load room data');
     // Grab the user and room information; otherwise, redirect to the join page
     if (checkLocationState(location, 'user', 'roomId')) {
       // Call GET endpoint to get latest room info
@@ -218,7 +216,6 @@ function LobbyPage() {
 
   // Connect the user to the room.
   useEffect(() => {
-    console.log('useEffect - connecdt to room');
     if (!socketConnected && currentRoomId && currentUser && currentUser.userId) {
       connectUserToRoom(currentRoomId, currentUser.userId);
     }

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -172,6 +172,7 @@ function LobbyPage() {
      */
     const subscribeCallback = (result: Message) => {
       setStateFromRoom(JSON.parse(result.body));
+      console.log(JSON.parse(result.body).host);
     };
 
     connect(roomId, userId).then(() => {
@@ -187,6 +188,7 @@ function LobbyPage() {
 
   // Grab the nickname variable and add the user to the lobby.
   useEffect(() => {
+    console.log('useEffect - load room data');
     // Grab the user and room information; otherwise, redirect to the join page
     if (checkLocationState(location, 'user', 'roomId')) {
       // Call GET endpoint to get latest room info
@@ -194,7 +196,7 @@ function LobbyPage() {
         .then((res) => {
           setStateFromRoom(res);
           // Reset the user to hold the ID.
-          res.inactiveUsers.forEach((user: User) => {
+          res.users.forEach((user: User) => {
             if (user.nickname === location.state.user.nickname) {
               setCurrentUser(user);
             }
@@ -216,6 +218,7 @@ function LobbyPage() {
 
   // Connect the user to the room.
   useEffect(() => {
+    console.log('useEffect - connecdt to room');
     if (!socketConnected && currentRoomId && currentUser && currentUser.userId) {
       connectUserToRoom(currentRoomId, currentUser.userId);
     }

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -182,7 +182,7 @@ public class RoomService {
     }
 
     // This function randomly assigns a new host in the room
-    public void conditionallyUpdateRoomHost(Room room, User user) {
+    public RoomDto conditionallyUpdateRoomHost(Room room, User user) {
         // If the disconnected user is the host and another active user is present, reassign the host for the room.
         if (room.getHost().equals(user)) {
             UpdateHostRequest request = new UpdateHostRequest();
@@ -198,9 +198,11 @@ public class RoomService {
 
             // Determine whether an active non-host user was found, and if so, send an update room host request.
             if (request.getNewHost() != null) {
-                updateRoomHost(room.getRoomId(), request);
+                return updateRoomHost(room.getRoomId(), request);
             }
         }
+        // If conditions fail to match, just return the room as it is
+        return RoomMapper.toDto(room);
     }
 
     public RoomDto updateRoomSettings(String roomId, UpdateSettingsRequest request) {

--- a/src/main/java/com/rocketden/main/socket/WebSocketConnectionEvents.java
+++ b/src/main/java/com/rocketden/main/socket/WebSocketConnectionEvents.java
@@ -64,6 +64,13 @@ public class WebSocketConnectionEvents {
         // Get the unique auto-generated session ID for this connection.
         String sessionId = sha.getSessionId();
 
+        // Pause for 0.5 seconds to allow any pending DB updates to flush to disk
+        try {
+            Thread.sleep(500);
+        } catch (Exception e) {
+            System.out.println("Thread sleep failed on socket connection");
+        }
+
         // Update the session ID of the relevant user, if it is found.
         User user = userRepository.findUserByUserId(userId);
         if (user != null) {

--- a/src/main/java/com/rocketden/main/socket/WebSocketConnectionEvents.java
+++ b/src/main/java/com/rocketden/main/socket/WebSocketConnectionEvents.java
@@ -92,8 +92,7 @@ public class WebSocketConnectionEvents {
 
             // Get room, conditionally update the host, and send socket update.
             Room room = user.getRoom();
-            roomService.conditionallyUpdateRoomHost(room, user);
-            RoomDto roomDto = RoomMapper.toDto(room);
+            RoomDto roomDto = roomService.conditionallyUpdateRoomHost(room, user);
             socketService.sendSocketUpdate(roomDto);
         }
     }


### PR DESCRIPTION
### List of Changes:

* Fixes #51 where a "socket already connected" error is shown on navigation with back/forward buttons
* Fixes #60 where lobby page shows wrong info on page refresh or reopening (CTRL+SHIFT+T)

### Notes:

* In order to avoid introducing another bug (where users receive socket messages with the wrong host due to the host change not flushing to the DB in time), I added a 0.5 second delay to the socket connection event listener

