### PR TITLE
Add an explanation field to problem test cases.

### DIFF
--- a/src/main/java/com/rocketden/main/dto/problem/CreateTestCaseRequest.java
+++ b/src/main/java/com/rocketden/main/dto/problem/CreateTestCaseRequest.java
@@ -9,4 +9,5 @@ public class CreateTestCaseRequest {
     private String input;
     private String output;
     private boolean hidden = false;
+    private String explanation;
 }

--- a/src/main/java/com/rocketden/main/dto/problem/ProblemTestCaseDto.java
+++ b/src/main/java/com/rocketden/main/dto/problem/ProblemTestCaseDto.java
@@ -11,4 +11,5 @@ public class ProblemTestCaseDto {
     private String input;
     private String output;
     private boolean hidden;
+    private String explanation;
 }

--- a/src/main/java/com/rocketden/main/model/problem/ProblemTestCase.java
+++ b/src/main/java/com/rocketden/main/model/problem/ProblemTestCase.java
@@ -35,4 +35,7 @@ public class ProblemTestCase {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "problem_table_id")
     private Problem problem;
+
+    @EqualsAndHashCode.Include
+    private String explanation;
 }

--- a/src/main/java/com/rocketden/main/service/ProblemService.java
+++ b/src/main/java/com/rocketden/main/service/ProblemService.java
@@ -96,6 +96,7 @@ public class ProblemService {
             throw new ApiException(ProblemError.NOT_FOUND);
         }
 
+        // Problem input and output are the two required fields.
         if (request.getInput() == null || request.getOutput() == null) {
             throw new ApiException(ProblemError.EMPTY_FIELD);
         }
@@ -103,7 +104,12 @@ public class ProblemService {
         ProblemTestCase testCase = new ProblemTestCase();
         testCase.setInput(request.getInput());
         testCase.setOutput(request.getOutput());
+
+        // Test case is not hidden by default.
         testCase.setHidden(request.isHidden());
+
+        // Explanation may be null, indicating no explanation is attached.
+        testCase.setExplanation(request.getExplanation());
 
         problem.addTestCase(testCase);
         repository.save(problem);

--- a/src/test/java/com/rocketden/main/api/ProblemTests.java
+++ b/src/test/java/com/rocketden/main/api/ProblemTests.java
@@ -59,8 +59,10 @@ class ProblemTests {
 
     private static final String INPUT = "[1, 8, 2]";
     private static final String OUTPUT = "[1, 2, 8]";
+    private static final String EXPLANATION = "2 < 8, so those are swapped.";
     private static final String INPUT_2 = "[-1, 5, 0, 3]";
     private static final String OUTPUT_2 = "5";
+    private static final String EXPLANATION_2 = "5 is the greatest number.";
 
     /**
      * Helper method that sends a POST request to create a new problem
@@ -233,6 +235,7 @@ class ProblemTests {
         CreateTestCaseRequest request = new CreateTestCaseRequest();
         request.setInput(INPUT);
         request.setOutput(OUTPUT);
+        request.setExplanation(EXPLANATION);
 
         String endpoint = String.format(POST_TEST_CASE_CREATE, problem.getProblemId());
         MvcResult result = this.mockMvc.perform(post(endpoint)
@@ -246,6 +249,7 @@ class ProblemTests {
 
         assertEquals(INPUT, actual.getInput());
         assertEquals(OUTPUT, actual.getOutput());
+        assertEquals(EXPLANATION, actual.getExplanation());
         assertFalse(actual.isHidden());
     }
 
@@ -276,6 +280,7 @@ class ProblemTests {
         CreateTestCaseRequest request = new CreateTestCaseRequest();
         request.setInput(INPUT);
         request.setOutput(OUTPUT);
+        request.setExplanation(EXPLANATION);
 
         ApiError ERROR = ProblemError.NOT_FOUND;
 

--- a/src/test/java/com/rocketden/main/api/ProblemTests.java
+++ b/src/test/java/com/rocketden/main/api/ProblemTests.java
@@ -1,5 +1,6 @@
 package com.rocketden.main.api;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -13,7 +14,6 @@ import com.google.gson.reflect.TypeToken;
 import com.rocketden.main.dto.problem.CreateProblemRequest;
 import com.rocketden.main.dto.problem.CreateTestCaseRequest;
 import com.rocketden.main.dto.problem.ProblemDto;
-import com.rocketden.main.dto.problem.ProblemSettingsDto;
 import com.rocketden.main.dto.problem.ProblemTestCaseDto;
 import com.rocketden.main.exception.ProblemError;
 import com.rocketden.main.exception.api.ApiError;
@@ -254,6 +254,30 @@ class ProblemTests {
     }
 
     @Test
+    public void createTestCaseNoExplanationSuccess() throws Exception {
+        ProblemDto problem = createSingleProblem();
+
+        CreateTestCaseRequest request = new CreateTestCaseRequest();
+        request.setInput(INPUT);
+        request.setOutput(OUTPUT);
+
+        String endpoint = String.format(POST_TEST_CASE_CREATE, problem.getProblemId());
+        MvcResult result = this.mockMvc.perform(post(endpoint)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(UtilityTestMethods.convertObjectToJsonString(request)))
+                .andDo(print()).andExpect(status().isCreated())
+                .andReturn();
+
+        String jsonResponse = result.getResponse().getContentAsString();
+        ProblemTestCaseDto actual = UtilityTestMethods.toObject(jsonResponse, ProblemTestCaseDto.class);
+
+        assertEquals(INPUT, actual.getInput());
+        assertEquals(OUTPUT, actual.getOutput());
+        assertNull(actual.getExplanation());
+        assertFalse(actual.isHidden());
+    }
+
+    @Test
     public void createTestCaseEmptyField() throws Exception {
         ProblemDto problem = createSingleProblem();
 
@@ -305,6 +329,7 @@ class ProblemTests {
         CreateTestCaseRequest request = new CreateTestCaseRequest();
         request.setInput(INPUT);
         request.setOutput(OUTPUT);
+        request.setExplanation(EXPLANATION);
         request.setHidden(true);
 
         String endpoint = String.format(POST_TEST_CASE_CREATE, problem.getProblemId());
@@ -317,6 +342,7 @@ class ProblemTests {
         // Create second test case
         request.setInput(INPUT_2);
         request.setOutput(OUTPUT_2);
+        request.setExplanation(EXPLANATION_2);
         request.setHidden(false);
 
         this.mockMvc.perform(post(endpoint)
@@ -341,10 +367,12 @@ class ProblemTests {
 
         assertEquals(INPUT, case1.getInput());
         assertEquals(OUTPUT, case1.getOutput());
+        assertEquals(EXPLANATION, case1.getExplanation());
         assertTrue(case1.isHidden());
 
         assertEquals(INPUT_2, case2.getInput());
         assertEquals(OUTPUT_2, case2.getOutput());
+        assertEquals(EXPLANATION_2, case2.getExplanation());
         assertFalse(case2.isHidden());
     }
 

--- a/src/test/java/com/rocketden/main/entity/ProblemEntityTests.java
+++ b/src/test/java/com/rocketden/main/entity/ProblemEntityTests.java
@@ -16,6 +16,7 @@ public class ProblemEntityTests {
     private static final int ID = 10;
     private static final String INPUT = "[1, 8, 2]";
     private static final String OUTPUT = "[1, 2, 8]";
+    private static final String EXPLANATION = "2 < 8, so those are swapped.";
 
     @Test
     public void problemInitialization() {
@@ -46,12 +47,14 @@ public class ProblemEntityTests {
         testCase.setId(ID);
         testCase.setInput(INPUT);
         testCase.setOutput(OUTPUT);
+        testCase.setExplanation(EXPLANATION);
 
         problem.addTestCase(testCase);
 
         ProblemTestCase caseToRemove = new ProblemTestCase();
         caseToRemove.setInput(INPUT);
         caseToRemove.setOutput(OUTPUT);
+        caseToRemove.setExplanation(EXPLANATION);
         caseToRemove.setHidden(true);
 
         assertFalse(problem.removeTestCase(caseToRemove));

--- a/src/test/java/com/rocketden/main/entity/ProblemEntityTests.java
+++ b/src/test/java/com/rocketden/main/entity/ProblemEntityTests.java
@@ -32,6 +32,7 @@ public class ProblemEntityTests {
         Problem problem = new Problem();
         ProblemTestCase testCase = new ProblemTestCase();
 
+        // The function has no restrictions on necessary test case components.
         problem.addTestCase(testCase);
 
         assertEquals(1, problem.getTestCases().size());
@@ -61,7 +62,10 @@ public class ProblemEntityTests {
 
         caseToRemove.setId(ID);
         caseToRemove.setHidden(false);
+
+        // Function returns true to remove test case, then false once deleted.
         assertTrue(problem.removeTestCase(caseToRemove));
+        assertFalse(problem.removeTestCase(caseToRemove));
         assertTrue(problem.getTestCases().isEmpty());
     }
 }

--- a/src/test/java/com/rocketden/main/mapper/ProblemMapperTests.java
+++ b/src/test/java/com/rocketden/main/mapper/ProblemMapperTests.java
@@ -22,6 +22,7 @@ public class ProblemMapperTests {
 
     private static final String INPUT = "[1, 8, 2]";
     private static final String OUTPUT = "[1, 2, 8]";
+    private static final String EXPLANATION = "2 < 8, so those are swapped.";
 
     @Test
     public void entityToDto() {
@@ -33,6 +34,7 @@ public class ProblemMapperTests {
         ProblemTestCase testCase = new ProblemTestCase();
         testCase.setInput(INPUT);
         testCase.setOutput(OUTPUT);
+        testCase.setExplanation(EXPLANATION);
         testCase.setHidden(true);
         expected.addTestCase(testCase);
 
@@ -57,11 +59,13 @@ public class ProblemMapperTests {
         expected.setInput(INPUT);
         expected.setOutput(OUTPUT);
         expected.setHidden(false);
+        expected.setExplanation(EXPLANATION);
 
         ProblemTestCaseDto actual = ProblemMapper.toTestCaseDto(expected);
 
         assertEquals(expected.getInput(), actual.getInput());
         assertEquals(expected.getOutput(), actual.getOutput());
         assertEquals(expected.getHidden(), actual.isHidden());
+        assertEquals(expected.getExplanation(), actual.getExplanation());
     }
 }

--- a/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
@@ -46,6 +46,7 @@ public class ProblemServiceTests {
 
     private static final String INPUT = "[1, 8, 2]";
     private static final String OUTPUT = "[1, 2, 8]";
+    private static final String EXPLANATION = "2 < 8, so those are swapped.";
 
     @Test
     public void getProblemSuccess() {
@@ -57,6 +58,7 @@ public class ProblemServiceTests {
         ProblemTestCase testCase = new ProblemTestCase();
         testCase.setInput(INPUT);
         testCase.setOutput(OUTPUT);
+        testCase.setExplanation(EXPLANATION);
         expected.addTestCase(testCase);
 
         Mockito.doReturn(expected).when(repository).findProblemByProblemId(expected.getProblemId());
@@ -70,6 +72,7 @@ public class ProblemServiceTests {
 
         assertEquals(expected.getTestCases().get(0).getInput(), response.getTestCases().get(0).getInput());
         assertEquals(expected.getTestCases().get(0).getOutput(), response.getTestCases().get(0).getOutput());
+        assertEquals(expected.getTestCases().get(0).getExplanation(), response.getTestCases().get(0).getExplanation());
     }
 
     @Test
@@ -168,6 +171,7 @@ public class ProblemServiceTests {
         request.setInput(INPUT);
         request.setOutput(OUTPUT);
         request.setHidden(true);
+        request.setExplanation(EXPLANATION);
 
         ProblemTestCaseDto response = problemService.createTestCase(expected.getProblemId(), request);
 
@@ -176,6 +180,7 @@ public class ProblemServiceTests {
         assertEquals(INPUT, response.getInput());
         assertEquals(OUTPUT, response.getOutput());
         assertTrue(response.isHidden());
+        assertEquals(EXPLANATION, response.getExplanation());
 
         // The created test case should be added to this problem
         assertEquals(1, expected.getTestCases().size());

--- a/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
@@ -20,7 +20,6 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 


### PR DESCRIPTION
#### This branch is set to merge into `QuickBuild`, #77.

### List of Changes:

- Add an `explanation` field to the `ProblemTestCase` object, which can be used to provide an explanation for more complicated test cases for players.
- Make relevant changes to add the `explanation` field to codebase tests.

### Notes:

- This PR does not have any changes to the current MVP, as the test case explanation is not shown in the UI next to the Input and Output; however, this can be used later to explain more complicated test cases to the players.
- I made a couple extraneous changes in the files containing problem test case components, including adding clarifying comments and removing unused imports.
- The `explanation` field is default set to `null` (which means no explanation is included). Eventually, this field (and the `description` field of the `Problem` object) could be a "markdown" object and support that style -- but that is far past the MVP.

### Screencast and Images:

There are no changes to the UI, so no screencasts or images are attached here.
