### PR TITLE
Add numProblems as an updatable room setting

### DIFF
--- a/src/main/java/com/rocketden/main/dto/room/RoomDto.java
+++ b/src/main/java/com/rocketden/main/dto/room/RoomDto.java
@@ -19,4 +19,5 @@ public class RoomDto {
     private List<UserDto> inactiveUsers;
     private boolean active;
     private ProblemDifficulty difficulty;
+    private int numProblems;
 }

--- a/src/main/java/com/rocketden/main/dto/room/UpdateSettingsRequest.java
+++ b/src/main/java/com/rocketden/main/dto/room/UpdateSettingsRequest.java
@@ -10,4 +10,5 @@ import lombok.Setter;
 public class UpdateSettingsRequest {
     private UserDto initiator;
     private ProblemDifficulty difficulty;
+    private Integer numProblems;
 }

--- a/src/main/java/com/rocketden/main/exception/ProblemError.java
+++ b/src/main/java/com/rocketden/main/exception/ProblemError.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 public enum ProblemError implements ApiError {
 
     BAD_DIFFICULTY(HttpStatus.BAD_REQUEST, "Please choose either Easy, Medium, or Hard (or Random if choosing a room difficulty)"),
-    BAD_NUMBER_PROBLEMS(HttpStatus.BAD_REQUEST, "Please choose a number of problems."),
     INVALID_NUMBER_REQUEST(HttpStatus.BAD_REQUEST, "Please request a valid number of problems."),
     EMPTY_FIELD(HttpStatus.BAD_REQUEST, "Please enter a value for each required field."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "A problem could not be found with the given criteria.");

--- a/src/main/java/com/rocketden/main/model/Room.java
+++ b/src/main/java/com/rocketden/main/model/Room.java
@@ -53,6 +53,8 @@ public class Room {
     @Enumerated(EnumType.STRING)
     private ProblemDifficulty difficulty = ProblemDifficulty.RANDOM;
 
+    private int numProblems = 1;
+
     public void addUser(User user) {
         users.add(user);
         user.setRoom(this);

--- a/src/main/java/com/rocketden/main/model/Room.java
+++ b/src/main/java/com/rocketden/main/model/Room.java
@@ -53,7 +53,7 @@ public class Room {
     @Enumerated(EnumType.STRING)
     private ProblemDifficulty difficulty = ProblemDifficulty.RANDOM;
 
-    private int numProblems = 1;
+    private Integer numProblems = 1;
 
     public void addUser(User user) {
         users.add(user);

--- a/src/main/java/com/rocketden/main/service/GameManagementService.java
+++ b/src/main/java/com/rocketden/main/service/GameManagementService.java
@@ -94,7 +94,7 @@ public class GameManagementService {
     // Initialize and add a game object from a room object
     public void createAddGameFromRoom(Room room) {
         Game game = GameMapper.fromRoom(room);
-        List<Problem> problems = problemService.getProblemsFromDifficulty(room.getDifficulty(), 1);
+        List<Problem> problems = problemService.getProblemsFromDifficulty(room.getDifficulty(), room.getNumProblems());
         game.setProblems(problems);
         currentGameMap.put(room.getRoomId(), game);
     }

--- a/src/main/java/com/rocketden/main/service/GameManagementService.java
+++ b/src/main/java/com/rocketden/main/service/GameManagementService.java
@@ -80,11 +80,11 @@ public class GameManagementService {
             throw new ApiException(RoomError.INVALID_PERMISSIONS);
         }
 
-        room.setActive(true);
-        repository.save(room);
-
         // Initialize game state
         createAddGameFromRoom(room);
+
+        room.setActive(true);
+        repository.save(room);
 
         RoomDto roomDto = RoomMapper.toDto(room);
         socketService.sendSocketUpdate(roomDto);

--- a/src/main/java/com/rocketden/main/service/ProblemService.java
+++ b/src/main/java/com/rocketden/main/service/ProblemService.java
@@ -92,8 +92,13 @@ public class ProblemService {
             throw new ApiException(ProblemError.NOT_FOUND);
         }
 
-        if (numProblems <= 0 || (numProblems > problems.size())) {
+        if (numProblems <= 0) {
             throw new ApiException(ProblemError.INVALID_NUMBER_REQUEST);
+        }
+
+        // If the user wants more problems than exists, just return all of them
+        if (numProblems > problems.size()) {
+            return problems;
         }
 
         // Get numProblem random integers used to map to problems.

--- a/src/main/java/com/rocketden/main/service/ProblemService.java
+++ b/src/main/java/com/rocketden/main/service/ProblemService.java
@@ -75,10 +75,8 @@ public class ProblemService {
      * @param numProblems The number of problems to fetch.
      */
     public List<Problem> getProblemsFromDifficulty(ProblemDifficulty difficulty, Integer numProblems) {
-        if (difficulty == null) {
-            throw new ApiException(ProblemError.BAD_DIFFICULTY);
-        } else if (numProblems == null) {
-            throw new ApiException(ProblemError.BAD_NUMBER_PROBLEMS);
+        if (difficulty == null || numProblems == null) {
+            throw new ApiException(ProblemError.EMPTY_FIELD);
         }
 
         List<Problem> problems;

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -221,6 +221,12 @@ public class RoomService {
         if (request.getDifficulty() != null) {
             room.setDifficulty(request.getDifficulty());
         }
+
+        // Set number of problems if not null
+        if (request.getNumProblems() != null) {
+            room.setNumProblems(request.getNumProblems());
+        }
+
         repository.save(room);
 
         RoomDto roomDto = RoomMapper.toDto(room);

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -9,6 +9,7 @@ import com.rocketden.main.dto.room.UpdateHostRequest;
 import com.rocketden.main.dto.room.UpdateSettingsRequest;
 import com.rocketden.main.dto.room.RemoveUserRequest;
 import com.rocketden.main.dto.user.UserMapper;
+import com.rocketden.main.exception.ProblemError;
 import com.rocketden.main.exception.RoomError;
 import com.rocketden.main.exception.UserError;
 import com.rocketden.main.exception.api.ApiException;
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Service;
 public class RoomService {
 
     public static final int ROOM_ID_LENGTH = 6;
+    public static final int MAX_NUM_PROBLEMS = 10;
 
     private final RoomRepository repository;
     private final SocketService socketService;
@@ -224,6 +226,9 @@ public class RoomService {
 
         // Set number of problems if not null
         if (request.getNumProblems() != null) {
+            if (request.getNumProblems() <= 0 || request.getNumProblems() > MAX_NUM_PROBLEMS) {
+                throw new ApiException(ProblemError.INVALID_NUMBER_REQUEST);
+            }
             room.setNumProblems(request.getNumProblems());
         }
 

--- a/src/test/java/com/rocketden/main/api/RoomTests.java
+++ b/src/test/java/com/rocketden/main/api/RoomTests.java
@@ -24,7 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/src/test/java/com/rocketden/main/api/RoomTests.java
+++ b/src/test/java/com/rocketden/main/api/RoomTests.java
@@ -405,6 +405,7 @@ public class RoomTests {
         UpdateSettingsRequest updateRequest = new UpdateSettingsRequest();
         updateRequest.setInitiator(host);
         updateRequest.setDifficulty(ProblemDifficulty.EASY);
+        updateRequest.setNumProblems(2);
 
         MvcResult result = this.mockMvc.perform(put(String.format(PUT_ROOM_SETTINGS, room.getRoomId()))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -426,6 +427,7 @@ public class RoomTests {
         RoomDto actual = UtilityTestMethods.toObject(jsonResponse, RoomDto.class);
 
         assertEquals(updateRequest.getDifficulty(), actual.getDifficulty());
+        assertEquals(updateRequest.getNumProblems(), actual.getNumProblems());
     }
 
     @Test
@@ -450,6 +452,7 @@ public class RoomTests {
 
         // Difficulty remains unchanged from default
         assertEquals(ProblemDifficulty.RANDOM, room.getDifficulty());
+        assertEquals(1, room.getNumProblems());
     }
 
     @Test

--- a/src/test/java/com/rocketden/main/mapper/RoomMapperTests.java
+++ b/src/test/java/com/rocketden/main/mapper/RoomMapperTests.java
@@ -10,13 +10,13 @@ import com.rocketden.main.model.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @SpringBootTest
 public class RoomMapperTests {
@@ -43,6 +43,7 @@ public class RoomMapperTests {
         room.setRoomId(ROOM_ID);
         room.setDifficulty(ProblemDifficulty.MEDIUM);
         room.setHost(host);
+        room.setNumProblems(3);
 
         room.addUser(host);
         room.addUser(user);
@@ -52,6 +53,7 @@ public class RoomMapperTests {
         assertNotNull(response);
         assertEquals(room.getRoomId(), response.getRoomId());
         assertEquals(room.getDifficulty(), response.getDifficulty());
+        assertEquals(room.getNumProblems(), response.getNumProblems());
 
         User actualHost = UserMapper.toEntity(response.getHost());
         assertEquals(room.getHost(), actualHost);

--- a/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
@@ -284,6 +284,7 @@ public class ProblemServiceTests {
         ApiException exception = assertThrows(ApiException.class, () -> problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, 10));
 
         assertEquals(ProblemError.INVALID_NUMBER_REQUEST, exception.getError());
+        // TODO
     }
 
     @Test

--- a/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
@@ -186,7 +186,8 @@ public class ProblemServiceTests {
         noProblemRequest.setInput(INPUT);
         noProblemRequest.setOutput(OUTPUT);
 
-        ApiException exception = assertThrows(ApiException.class, () -> problemService.createTestCase("Z", noProblemRequest));
+        ApiException exception = assertThrows(ApiException.class, () ->
+                problemService.createTestCase("Z", noProblemRequest));
 
         verify(repository, never()).save(Mockito.any());
         assertEquals(ProblemError.NOT_FOUND, exception.getError());
@@ -201,7 +202,8 @@ public class ProblemServiceTests {
 
         Mockito.doReturn(problem).when(repository).findProblemByProblemId(problemId);
 
-        exception = assertThrows(ApiException.class, () -> problemService.createTestCase(problemId, emptyFieldRequest));
+        exception = assertThrows(ApiException.class, () ->
+                problemService.createTestCase(problemId, emptyFieldRequest));
 
         verify(repository, never()).save(Mockito.any());
         assertEquals(ProblemError.EMPTY_FIELD, exception.getError());
@@ -249,14 +251,16 @@ public class ProblemServiceTests {
 
     @Test
     public void getRandomProblemNullDifficulty() {
-        ApiException exception = assertThrows(ApiException.class, () -> problemService.getProblemsFromDifficulty(null, 1));
+        ApiException exception = assertThrows(ApiException.class, () ->
+                problemService.getProblemsFromDifficulty(null, 1));
 
         assertEquals(ProblemError.BAD_DIFFICULTY, exception.getError());
     }
 
     @Test
     public void getRandomProblemNullNumProblems() {
-        ApiException exception = assertThrows(ApiException.class, () -> problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, null));
+        ApiException exception = assertThrows(ApiException.class, () ->
+                problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, null));
 
         assertEquals(ProblemError.BAD_NUMBER_PROBLEMS, exception.getError());
     }
@@ -269,7 +273,8 @@ public class ProblemServiceTests {
 
         Mockito.doReturn(problems).when(repository).findAll();
 
-        ApiException exception = assertThrows(ApiException.class, () -> problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, 0));
+        ApiException exception = assertThrows(ApiException.class, () ->
+                problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, 0));
 
         assertEquals(ProblemError.INVALID_NUMBER_REQUEST, exception.getError());
     }
@@ -282,28 +287,16 @@ public class ProblemServiceTests {
 
         Mockito.doReturn(problems).when(repository).findAll();
 
-        ApiException exception = assertThrows(ApiException.class, () -> problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, -3));
+        ApiException exception = assertThrows(ApiException.class, () ->
+                problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, -3));
 
         assertEquals(ProblemError.INVALID_NUMBER_REQUEST, exception.getError());
-    }
-
-    @Test
-    public void getRandomProblemExcessiveNumProblems() {
-        Problem problem1 = new Problem();
-        problem1.setDifficulty(ProblemDifficulty.MEDIUM);
-        List<Problem> problems = Collections.singletonList(problem1);
-
-        Mockito.doReturn(problems).when(repository).findAll();
-
-        ApiException exception = assertThrows(ApiException.class, () -> problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, 10));
-
-        assertEquals(ProblemError.INVALID_NUMBER_REQUEST, exception.getError());
-        // TODO
     }
 
     @Test
     public void getRandomProblemNotFound() {
-        ApiException exception = assertThrows(ApiException.class, () -> problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, 1));
+        ApiException exception = assertThrows(ApiException.class, () ->
+                problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, 1));
 
         assertEquals(ProblemError.NOT_FOUND, exception.getError());
     }

--- a/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
@@ -254,7 +254,7 @@ public class ProblemServiceTests {
         ApiException exception = assertThrows(ApiException.class, () ->
                 problemService.getProblemsFromDifficulty(null, 1));
 
-        assertEquals(ProblemError.BAD_DIFFICULTY, exception.getError());
+        assertEquals(ProblemError.EMPTY_FIELD, exception.getError());
     }
 
     @Test
@@ -262,7 +262,7 @@ public class ProblemServiceTests {
         ApiException exception = assertThrows(ApiException.class, () ->
                 problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, null));
 
-        assertEquals(ProblemError.BAD_NUMBER_PROBLEMS, exception.getError());
+        assertEquals(ProblemError.EMPTY_FIELD, exception.getError());
     }
 
     @Test

--- a/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
@@ -234,6 +234,20 @@ public class ProblemServiceTests {
     }
 
     @Test
+    public void getRandomProblemExceedsAvailableProblems() {
+        Problem problem1 = new Problem();
+        problem1.setDifficulty(ProblemDifficulty.MEDIUM);
+        List<Problem> problems = Collections.singletonList(problem1);
+
+        Mockito.doReturn(problems).when(repository).findAll();
+
+        // Return correct problem when selecting random difficulty
+        List<Problem> response = problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, 3);
+        assertEquals(1, response.size());
+        assertEquals(problem1.getProblemId(), response.get(0).getProblemId());
+    }
+
+    @Test
     public void getRandomProblemNullDifficulty() {
         ApiException exception = assertThrows(ApiException.class, () -> problemService.getProblemsFromDifficulty(null, 1));
 

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -375,6 +375,30 @@ public class RoomServiceTests {
     }
 
     @Test
+    public void updateRoomSettingsExceedsMaxProblems() {
+        Room room = new Room();
+        room.setRoomId(ROOM_ID);
+
+        User host = new User();
+        host.setNickname(NICKNAME);
+
+        room.setHost(host);
+        room.addUser(host);
+
+        Mockito.doReturn(room).when(repository).findRoomByRoomId(eq(ROOM_ID));
+
+        UpdateSettingsRequest request = new UpdateSettingsRequest();
+        request.setInitiator(UserMapper.toDto(host));
+        request.setNumProblems(RoomService.MAX_NUM_PROBLEMS + 1);
+
+        RoomDto response = roomService.updateRoomSettings(room.getRoomId(), request);
+
+        ApiException exception = assertThrows(ApiException.class, () ->
+                roomService.updateRoomSettings(ROOM_ID, request));
+        assertEquals(ProblemError.INVALID_NUMBER_REQUEST, exception.getError());
+    }
+
+    @Test
     public void removeUserSuccess() {
         Room room = new Room();
         room.setRoomId(ROOM_ID);

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -27,7 +27,7 @@ import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -367,8 +367,6 @@ public class RoomServiceTests {
         request.setInitiator(UserMapper.toDto(host));
         request.setNumProblems(-1);
 
-        RoomDto response = roomService.updateRoomSettings(room.getRoomId(), request);
-
         ApiException exception = assertThrows(ApiException.class, () ->
                 roomService.updateRoomSettings(ROOM_ID, request));
         assertEquals(ProblemError.INVALID_NUMBER_REQUEST, exception.getError());
@@ -390,8 +388,6 @@ public class RoomServiceTests {
         UpdateSettingsRequest request = new UpdateSettingsRequest();
         request.setInitiator(UserMapper.toDto(host));
         request.setNumProblems(RoomService.MAX_NUM_PROBLEMS + 1);
-
-        RoomDto response = roomService.updateRoomSettings(room.getRoomId(), request);
 
         ApiException exception = assertThrows(ApiException.class, () ->
                 roomService.updateRoomSettings(ROOM_ID, request));


### PR DESCRIPTION
### List of Changes:

* Add numProblems as a customizable field to room objects
* Use numProblems setting from rooms to initialize game objects
* Create potential fixes for the invalid numProblems errors 
  * Set a max of 10 numProblems
  * If numProblems is more than total problems than exist, return as many problems as exists
  * Prevent room from being active if game creation fails

### Notes:

* I didn't add the ability to customize numProblems on the frontend since for the MVP I'm guessing we'll only be able to support solving one problem per game (the first problem) - let me know what your thoughts are on that
