### PR TITLE
Create frontend functionality for creating, updating, and deleting problems

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -34,6 +34,9 @@
                 "tsx": "never"
             }
         ],
+        "jsx-a11y/label-has-associated-control": [ 2, {
+            "controlComponents": ["CheckboxInput"]
+        }],
         "react/jsx-filename-extension": [1, { "extensions": [".tsx", ".jsx"] }],
         "react/jsx-props-no-spreading": "off"
     },

--- a/frontend/src/api/Problem.ts
+++ b/frontend/src/api/Problem.ts
@@ -79,8 +79,8 @@ export const getSingleProblem = (problemId: string): Promise<Problem> => axios
     throw axiosErrorHandler(err);
   });
 
-export const createProblem = (problemId: string, problem: Problem): Promise<Problem> => axios
-  .post<Problem>(routes.editProblem(problemId), problem)
+export const createProblem = (problem: Problem): Promise<Problem> => axios
+  .post<Problem>(routes.createProblem, problem)
   .then((res) => res.data)
   .catch((err) => {
     throw axiosErrorHandler(err);

--- a/frontend/src/api/Problem.ts
+++ b/frontend/src/api/Problem.ts
@@ -52,6 +52,8 @@ const routes = {
   createProblem: `${basePath}/`,
   getRandomProblem: `${basePath}/random`,
   getSingleProblem: (problemId: string) => `${basePath}/${problemId}`,
+  editProblem: (problemId: string) => `${basePath}/${problemId}`,
+  deleteProblem: (problemId: string) => `${basePath}/${problemId}`,
   createTestCase: (problemId: string) => `${basePath}/${problemId}/test-case`,
   defaultCodeMap: (problemId: string) => `${basePath}/${problemId}/default-code`,
 };
@@ -65,6 +67,34 @@ export const getProblems = (): Promise<Problem[]> => axios
 
 export const getRandomProblem = (request: ProblemSettings): Promise<Problem> => axios
   .get<Problem>(`${routes.getRandomProblem}?${new URLSearchParams(request).toString()}`)
+  .then((res) => res.data)
+  .catch((err) => {
+    throw axiosErrorHandler(err);
+  });
+
+export const getSingleProblem = (problemId: string): Promise<Problem> => axios
+  .get<Problem>(routes.getSingleProblem(problemId))
+  .then((res) => res.data)
+  .catch((err) => {
+    throw axiosErrorHandler(err);
+  });
+
+export const createProblem = (problemId: string, problem: Problem): Promise<Problem> => axios
+  .post<Problem>(routes.editProblem(problemId), problem)
+  .then((res) => res.data)
+  .catch((err) => {
+    throw axiosErrorHandler(err);
+  });
+
+export const editProblem = (problemId: string, updatedProblem: Problem): Promise<Problem> => axios
+  .put<Problem>(routes.editProblem(problemId), updatedProblem)
+  .then((res) => res.data)
+  .catch((err) => {
+    throw axiosErrorHandler(err);
+  });
+
+export const deleteProblem = (problemId: string): Promise<Problem> => axios
+  .delete<Problem>(routes.deleteProblem(problemId))
   .then((res) => res.data)
   .catch((err) => {
     throw axiosErrorHandler(err);

--- a/frontend/src/api/Problem.ts
+++ b/frontend/src/api/Problem.ts
@@ -7,14 +7,36 @@ export type TestCase = {
   input: string,
   output: string,
   hidden: boolean,
+  explanation: string,
 };
 
 export type Problem = {
   problemId: string,
   name: string,
-  description: string;
+  description: string,
+  difficulty: Difficulty,
   testCases: TestCase[],
+  problemInputs: ProblemInput[],
+  outputType: ProblemIOType,
 };
+
+export type ProblemInput = {
+  name: string,
+  type: ProblemIOType,
+};
+
+export enum ProblemIOType {
+  String = 'STRING',
+  Integer = 'INTEGER',
+  Double = 'DOUBLE',
+  Character = 'CHARACTER',
+  Boolean = 'BOOLEAN',
+  ArrayString = 'ARRAY_STRING',
+  ArrayInteger = 'ARRAY_INTEGER',
+  ArrayDouble = 'ARRAY_DOUBLE',
+  ArrayCharacter = 'ARRAY_CHARACTER',
+  ArrayBoolean = 'ARRAY_BOOLEAN',
+}
 
 export type ProblemSettings = {
   difficulty: Difficulty,

--- a/frontend/src/components/card/ProblemCard.tsx
+++ b/frontend/src/components/card/ProblemCard.tsx
@@ -8,6 +8,7 @@ import {
 
 type ProblemCardProps = {
   problem: Problem,
+  onClick: (problemId: string) => void,
 };
 
 const Content = styled.div`
@@ -19,10 +20,10 @@ const Content = styled.div`
 `;
 
 function ProblemCard(props: ProblemCardProps) {
-  const { problem } = props;
+  const { problem, onClick } = props;
 
   return (
-    <Content>
+    <Content onClick={() => onClick(problem.problemId)}>
       <FlexHorizontalContainer>
         <FlexLeft>
           <CenteredContainer>

--- a/frontend/src/components/card/ProblemCard.tsx
+++ b/frontend/src/components/card/ProblemCard.tsx
@@ -1,10 +1,46 @@
 import React from 'react';
+import styled from 'styled-components';
+import { Problem } from '../../api/Problem';
+import { Text } from '../core/Text';
+import {
+  CenteredContainer, FlexHorizontalContainer, FlexLeft, FlexRight,
+} from '../core/Container';
 
-function ProblemCard() {
+type ProblemCardProps = {
+  problem: Problem,
+};
+
+const Content = styled.div`
+  display: block;
+  margin: 10px;
+  border-radius: 5px;
+  box-shadow: 0 -1px 4px rgba(0, 0, 0, 0.12);
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+function ProblemCard(props: ProblemCardProps) {
+  const { problem } = props;
+
   return (
-    <div>
-      stuff
-    </div>
+    <Content>
+      <FlexHorizontalContainer>
+        <FlexLeft>
+          <CenteredContainer>
+            <Text bold>{problem.name}</Text>
+            <br />
+            <Text>{problem.description.substring(0, 50)}</Text>
+          </CenteredContainer>
+        </FlexLeft>
+
+        <FlexRight>
+          <CenteredContainer>
+            <Text>{problem.problemId}</Text>
+            <br />
+            <Text>{problem.difficulty}</Text>
+          </CenteredContainer>
+        </FlexRight>
+      </FlexHorizontalContainer>
+    </Content>
   );
 }
 

--- a/frontend/src/components/card/ProblemCard.tsx
+++ b/frontend/src/components/card/ProblemCard.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function ProblemCard() {
+  return (
+    <div>
+      stuff
+    </div>
+  );
+}
+
+export default ProblemCard;

--- a/frontend/src/components/card/ProblemCard.tsx
+++ b/frontend/src/components/card/ProblemCard.tsx
@@ -17,6 +17,10 @@ const Content = styled.div`
   border-radius: 5px;
   box-shadow: 0 -1px 4px rgba(0, 0, 0, 0.12);
   background-color: ${({ theme }) => theme.colors.white};
+  
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 function ProblemCard(props: ProblemCardProps) {

--- a/frontend/src/components/config/App.tsx
+++ b/frontend/src/components/config/App.tsx
@@ -10,6 +10,9 @@ import JoinGamePage from '../../views/Join';
 import CreateGamePage from '../../views/Create';
 import GameResultsPage from '../../views/Results';
 import LobbyPage from '../../views/Lobby';
+import AllProblemsPage from '../../views/AllProblemsPage';
+import ProblemPage from '../../views/ProblemPage';
+import CreateProblemPage from '../../views/CreateProblemPage';
 
 function App() {
   return (
@@ -20,6 +23,9 @@ function App() {
       <CustomRoute path="/game/create" component={CreateGamePage} layout={MainLayout} exact />
       <CustomRoute path="/game/lobby" component={LobbyPage} layout={MainLayout} exact />
       <CustomRoute path="/game/results" component={GameResultsPage} layout={MainLayout} exact />
+      <CustomRoute path="/problem/all" component={AllProblemsPage} layout={MainLayout} exact />
+      <CustomRoute path="/problem/create" component={CreateProblemPage} layout={MainLayout} exact />
+      <CustomRoute path="/problem/:id" component={ProblemPage} layout={MainLayout} exact />
       <CustomRoute path="*" component={NotFound} layout={MainLayout} />
     </Switch>
   );

--- a/frontend/src/components/config/App.tsx
+++ b/frontend/src/components/config/App.tsx
@@ -23,7 +23,7 @@ function App() {
       <CustomRoute path="/game/create" component={CreateGamePage} layout={MainLayout} exact />
       <CustomRoute path="/game/lobby" component={LobbyPage} layout={MainLayout} exact />
       <CustomRoute path="/game/results" component={GameResultsPage} layout={MainLayout} exact />
-      <CustomRoute path="/problem/all" component={AllProblemsPage} layout={MainLayout} exact />
+      <CustomRoute path="/problems/all" component={AllProblemsPage} layout={MainLayout} exact />
       <CustomRoute path="/problem/create" component={CreateProblemPage} layout={MainLayout} exact />
       <CustomRoute path="/problem/:id" component={ProblemPage} layout={MainLayout} exact />
       <CustomRoute path="*" component={NotFound} layout={MainLayout} />

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -78,7 +78,8 @@ type ProblemIOTypeButtonProps = {
 export const ProblemIOTypeButton = styled(DefaultButton)<ProblemIOTypeButtonProps>`  
   color: ${({ theme, active }) => (active ? theme.colors.white : theme.colors.font)};
   background-color: ${({ theme, active }) => (active ? theme.colors.blue : theme.colors.white)};
-  padding: 8px 16px;
+  padding: 4px 8px;
+  margin: 0.8rem;
   
   &:hover {
     ${({ theme }) => `

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -71,6 +71,25 @@ export const DifficultyButton = styled(DefaultButton)<DifficultyProps>`
   }
 `;
 
+type ProblemIOTypeButtonProps = {
+  active: boolean,
+}
+
+export const ProblemIOTypeButton = styled(DefaultButton)<ProblemIOTypeButtonProps>`  
+  color: ${({ theme, active }) => (active ? theme.colors.white : theme.colors.font)};
+  background-color: ${({ theme, active }) => (active ? theme.colors.blue : theme.colors.white)};
+  padding: 8px 16px;
+  
+  &:hover {
+    ${({ theme }) => `
+      color: ${theme.colors.white};
+      background-color: ${theme.colors.blue};
+    `};
+    
+    cursor: pointer;
+  }
+`;
+
 export const SmallButton = styled(DefaultButton)`
   color: ${({ theme }) => theme.colors.white};
   background-color: ${({ theme }) => theme.colors.blue};

--- a/frontend/src/components/core/Input.tsx
+++ b/frontend/src/components/core/Input.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const Input = styled.input`
+const Input = styled.input`
   box-sizing: border-box;
   border-radius: 0.25rem;
   border: 3px solid ${({ theme }) => theme.colors.blue};
@@ -62,6 +62,21 @@ export const NumberInput = styled(Input).attrs(() => ({
 }))`
   display: inline-block;
   width: 7rem;
+  text-align: center;
+  font-size: ${({ theme }) => theme.fontSize.mediumLarge};
+  padding: 1rem;
+  color: ${({ theme }) => theme.colors.text};
+
+  &:focus {
+    border: 3px solid ${({ theme }) => theme.colors.darkBlue};
+  }
+`;
+
+export const TextInput = styled(Input).attrs(() => ({
+  type: 'text',
+}))`
+  display: block;
+  width: 15rem;
   text-align: center;
   font-size: ${({ theme }) => theme.fontSize.mediumLarge};
   padding: 1rem;

--- a/frontend/src/components/core/Input.tsx
+++ b/frontend/src/components/core/Input.tsx
@@ -86,3 +86,12 @@ export const TextInput = styled(Input).attrs(() => ({
     border: 3px solid ${({ theme }) => theme.colors.darkBlue};
   }
 `;
+
+export const CheckboxInput = styled(Input).attrs(() => ({
+  type: 'checkbox',
+}))`
+  display: inline-block;
+  font-size: ${({ theme }) => theme.fontSize.mediumLarge};
+  color: ${({ theme }) => theme.colors.text};
+  margin: 5px;
+`;

--- a/frontend/src/components/core/Input.tsx
+++ b/frontend/src/components/core/Input.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const Input = styled.input`
+export const Input = styled.input`
   box-sizing: border-box;
   border-radius: 0.25rem;
   border: 3px solid ${({ theme }) => theme.colors.blue};

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -213,12 +213,11 @@ function ProblemDisplay(props: ProblemDisplayParams) {
                     e.target.value, newProblem.testCases[index].output)}
                 />
                 <br />
-                <ConsoleTextArea
+                <TextInput
                   value={newProblem.testCases[index].output}
                   onChange={(e) => handleTestCaseChange(index,
                     newProblem.testCases[index].input, e.target.value)}
                 />
-                <br />
                 <SmallButton onClick={() => deleteTestCase(index)}>Delete Test Case</SmallButton>
               </div>
             ))}

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { deleteProblem, Problem, ProblemIOType } from '../../api/Problem';
-import { LargeInputButton, TextInput } from '../core/Input';
+import { ConsoleTextArea, LargeInputButton, TextInput } from '../core/Input';
 import Difficulty from '../../api/Difficulty';
 import { DifficultyButton, ProblemIOTypeButton, SmallButton } from '../core/Button';
 import { MediumText, Text } from '../core/Text';
@@ -163,11 +163,12 @@ function ProblemDisplay(props: ProblemDisplayParams) {
       {newProblem.problemInputs.map((input, index) => (
         <div>
           <Text bold>{`Input ${index + 1}`}</Text>
-          <TextInput
+          <ConsoleTextArea
             value={newProblem.problemInputs[index].name}
             onChange={(e) => handleInputChange(index,
               e.target.value, newProblem.problemInputs[index].type)}
           />
+          <br />
 
           {Object.keys(ProblemIOType).map((key) => {
             const inputType = ProblemIOType[key as keyof typeof ProblemIOType];
@@ -206,16 +207,18 @@ function ProblemDisplay(props: ProblemDisplayParams) {
             {newProblem.testCases.map((testCase, index) => (
               <div>
                 <Text bold>{`Test Case ${index + 1}`}</Text>
-                <TextInput
+                <ConsoleTextArea
                   value={newProblem.testCases[index].input}
                   onChange={(e) => handleTestCaseChange(index,
                     e.target.value, newProblem.testCases[index].output)}
                 />
-                <TextInput
+                <br />
+                <ConsoleTextArea
                   value={newProblem.testCases[index].output}
                   onChange={(e) => handleTestCaseChange(index,
                     newProblem.testCases[index].input, e.target.value)}
                 />
+                <br />
                 <SmallButton onClick={() => deleteTestCase(index)}>Delete Test Case</SmallButton>
               </div>
             ))}

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -14,10 +14,13 @@ type ProblemDisplayParams = {
   problem: Problem,
   actionText: string,
   onClick: (newProblem: Problem) => void,
+  editMode: boolean,
 };
 
 function ProblemDisplay(props: ProblemDisplayParams) {
-  const { problem, onClick, actionText } = props;
+  const {
+    problem, onClick, actionText, editMode,
+  } = props;
   const [newProblem, setNewProblem] = useState<Problem>(problem);
 
   // Handle updating of normal text fields
@@ -170,24 +173,29 @@ function ProblemDisplay(props: ProblemDisplayParams) {
         );
       })}
 
-      <MediumText>Test Cases:</MediumText>
-      <SmallButton onClick={addTestCase}>Add Test Case</SmallButton>
-      {newProblem.testCases.map((testCase, index) => (
-        <div>
-          <Text bold>{`Test Case ${index + 1}`}</Text>
-          <TextInput
-            value={newProblem.testCases[index].input}
-            onChange={(e) => handleTestCaseChange(index,
-              e.target.value, newProblem.testCases[index].output)}
-          />
-          <TextInput
-            value={newProblem.testCases[index].output}
-            onChange={(e) => handleTestCaseChange(index,
-              newProblem.testCases[index].input, e.target.value)}
-          />
-          <SmallButton onClick={() => deleteTestCase(index)}>Delete Test Case</SmallButton>
-        </div>
-      ))}
+      {editMode
+        ? (
+          <div>
+            <MediumText>Test Cases:</MediumText>
+            <SmallButton onClick={addTestCase}>Add Test Case</SmallButton>
+            {newProblem.testCases.map((testCase, index) => (
+              <div>
+                <Text bold>{`Test Case ${index + 1}`}</Text>
+                <TextInput
+                  value={newProblem.testCases[index].input}
+                  onChange={(e) => handleTestCaseChange(index,
+                    e.target.value, newProblem.testCases[index].output)}
+                />
+                <TextInput
+                  value={newProblem.testCases[index].output}
+                  onChange={(e) => handleTestCaseChange(index,
+                    newProblem.testCases[index].input, e.target.value)}
+                />
+                <SmallButton onClick={() => deleteTestCase(index)}>Delete Test Case</SmallButton>
+              </div>
+            ))}
+          </div>
+        ) : null}
 
       <LargeInputButton value={actionText} onClick={() => onClick(newProblem)} />
     </Content>

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Problem } from '../../api/Problem';
-import { TextInput } from '../core/Input';
+import { LargeInputButton, TextInput } from '../core/Input';
 
 const Content = styled.div`
   padding: 10px;
@@ -9,24 +9,28 @@ const Content = styled.div`
 
 type ProblemDisplayParams = {
   problem: Problem,
+  onClick: (newProblem: Problem) => void,
 };
 
 function ProblemDisplay(props: ProblemDisplayParams) {
-  const { problem } = props;
+  const { problem, onClick } = props;
+  const [newProblem, setNewProblem] = useState<Problem>(problem);
 
   return (
     <Content>
       Name:
       <TextInput
-        value={problem.name}
-        onChange={(e) => { problem.name = e.target.value; }}
+        value={newProblem.name}
+        onChange={(e) => { newProblem.name = e.target.value; }}
       />
 
       Description:
       <TextInput
-        value={problem.description}
-        onChange={(e) => { problem.description = e.target.value; }}
+        value={newProblem.description}
+        onChange={(e) => { newProblem.description = e.target.value; }}
       />
+
+      <LargeInputButton onClick={() => onClick(problem)} />
     </Content>
   );
 }

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -139,7 +139,7 @@ function ProblemDisplay(props: ProblemDisplayParams) {
       />
 
       <MediumText>Description:</MediumText>
-      <TextInput
+      <ConsoleTextArea
         name="description"
         value={newProblem.description}
         onChange={handleChange}
@@ -166,7 +166,7 @@ function ProblemDisplay(props: ProblemDisplayParams) {
       {newProblem.problemInputs.map((input, index) => (
         <div>
           <Text bold>{`Input ${index + 1}`}</Text>
-          <ConsoleTextArea
+          <TextInput
             value={newProblem.problemInputs[index].name}
             onChange={(e) => handleInputChange(index,
               e.target.value, newProblem.problemInputs[index].type)}

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 import { Problem, ProblemIOType } from '../../api/Problem';
 import { LargeInputButton, TextInput } from '../core/Input';
 import Difficulty from '../../api/Difficulty';
-import { DifficultyButton } from '../core/Button';
+import { DifficultyButton, ProblemIOTypeButton } from '../core/Button';
+import { MediumText, Text } from '../core/Text';
 
 const Content = styled.div`
   padding: 10px;
@@ -31,29 +32,36 @@ function ProblemDisplay(props: ProblemDisplayParams) {
     });
   };
 
+  const handleEnumChange = (name: string, value: any) => handleChange({ target: { name, value } });
+
+  const handleInputChange = (index: number, name: string, type: ProblemIOType) => {
+    return 0;
+  };
+
   return (
     <Content>
-      Name:
+      <MediumText>Name:</MediumText>
       <TextInput
         name="name"
         value={newProblem.name}
         onChange={handleChange}
       />
 
-      Description:
+      <MediumText>Description:</MediumText>
       <TextInput
         name="description"
         value={newProblem.description}
         onChange={handleChange}
       />
 
+      <MediumText>Difficulty:</MediumText>
       {Object.keys(Difficulty).map((key) => {
         const difficulty = Difficulty[key as keyof typeof Difficulty];
         if (difficulty !== Difficulty.Random) {
           return (
             <DifficultyButton
-              onClick={() => handleChange({ target: 'difficulty', value: difficulty })}
-              active={difficulty === problem.difficulty}
+              onClick={() => handleEnumChange('difficulty', difficulty)}
+              active={difficulty === newProblem.difficulty}
               enabled
             >
               {key}
@@ -63,16 +71,41 @@ function ProblemDisplay(props: ProblemDisplayParams) {
         return null;
       })}
 
+      {newProblem.problemInputs.map((input, index) => (
+        <div>
+          <Text>{`Input ${index + 1}`}</Text>
+          <TextInput
+            name="name"
+            value={newProblem.name}
+            onChange={(e) => handleInputChange(index,
+              e.target.value, newProblem.problemInputs[index].type)}
+          />
+
+          {Object.keys(ProblemIOType).map((key) => {
+            const inputType = ProblemIOType[key as keyof typeof ProblemIOType];
+            return (
+              <ProblemIOTypeButton
+                onClick={() => handleInputChange(index,
+                  newProblem.problemInputs[index].name, inputType)}
+                active={inputType === newProblem.problemInputs[index].type}
+              >
+                {key}
+              </ProblemIOTypeButton>
+            );
+          })}
+        </div>
+      ))}
+
+      <MediumText>Output Type:</MediumText>
       {Object.keys(ProblemIOType).map((key) => {
         const outputType = ProblemIOType[key as keyof typeof ProblemIOType];
         return (
-          <DifficultyButton
-            onClick={() => handleChange({ target: 'outputType', value: outputType })}
-            active={outputType === problem.outputType}
-            enabled
+          <ProblemIOTypeButton
+            onClick={() => handleEnumChange('outputType', outputType)}
+            active={outputType === newProblem.outputType}
           >
             {key}
-          </DifficultyButton>
+          </ProblemIOTypeButton>
         );
       })}
 

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -93,7 +93,7 @@ function ProblemDisplay(props: ProblemDisplayParams) {
   const deleteTestCase = (index: number) => {
     setNewProblem({
       ...newProblem,
-      problemInputs: newProblem.problemInputs.filter((_, i) => index !== i),
+      testCases: newProblem.testCases.filter((_, i) => index !== i),
     });
   };
 
@@ -178,12 +178,12 @@ function ProblemDisplay(props: ProblemDisplayParams) {
           <TextInput
             value={newProblem.testCases[index].input}
             onChange={(e) => handleTestCaseChange(index,
-              e.target.value, newProblem.testCases[index].input)}
+              e.target.value, newProblem.testCases[index].output)}
           />
           <TextInput
-            value={newProblem.testCases[index].input}
+            value={newProblem.testCases[index].output}
             onChange={(e) => handleTestCaseChange(index,
-              e.target.value, newProblem.testCases[index].input)}
+              newProblem.testCases[index].input, e.target.value)}
           />
           <SmallButton onClick={() => deleteTestCase(index)}>Delete Test Case</SmallButton>
         </div>

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Problem } from '../../api/Problem';
+import { Input } from '../core/Input';
+
+const Content = styled.div`
+  padding: 10px;
+`;
+
+type ProblemDisplayParams = {
+  problem: Problem,
+};
+
+function ProblemDisplay(props: ProblemDisplayParams) {
+  const { problem } = props;
+
+  return (
+    <Content>
+      <Input
+        value={problem.name}
+        onChange={(e) => { problem.name = e.target.value; }}
+      />
+      <Input
+        value={problem.description}
+        onChange={(e) => { problem.description = e.target.value; }}
+      />
+    </Content>
+  );
+}
+
+export default ProblemDisplay;

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -16,21 +16,35 @@ function ProblemDisplay(props: ProblemDisplayParams) {
   const { problem, onClick } = props;
   const [newProblem, setNewProblem] = useState<Problem>(problem);
 
+  const handleChange = (e: any) => {
+    const { name, value } = e.target;
+    console.log({
+      ...newProblem,
+      [name]: value,
+    });
+    setNewProblem({
+      ...newProblem,
+      [name]: value,
+    });
+  };
+
   return (
     <Content>
       Name:
       <TextInput
+        name="name"
         value={newProblem.name}
-        onChange={(e) => { newProblem.name = e.target.value; }}
+        onChange={handleChange}
       />
 
       Description:
       <TextInput
+        name="description"
         value={newProblem.description}
-        onChange={(e) => { newProblem.description = e.target.value; }}
+        onChange={handleChange}
       />
 
-      <LargeInputButton onClick={() => onClick(problem)} />
+      <LargeInputButton value="Edit Problem" onClick={() => onClick(newProblem)} />
     </Content>
   );
 }

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Problem, ProblemIOType } from '../../api/Problem';
 import { LargeInputButton, TextInput } from '../core/Input';
 import Difficulty from '../../api/Difficulty';
-import { DifficultyButton, ProblemIOTypeButton } from '../core/Button';
+import { DifficultyButton, ProblemIOTypeButton, SmallButton } from '../core/Button';
 import { MediumText, Text } from '../core/Text';
 
 const Content = styled.div`
@@ -12,11 +12,12 @@ const Content = styled.div`
 
 type ProblemDisplayParams = {
   problem: Problem,
+  actionText: string,
   onClick: (newProblem: Problem) => void,
 };
 
 function ProblemDisplay(props: ProblemDisplayParams) {
-  const { problem, onClick } = props;
+  const { problem, onClick, actionText } = props;
   const [newProblem, setNewProblem] = useState<Problem>(problem);
 
   // Handle updating of normal text fields
@@ -41,6 +42,22 @@ function ProblemDisplay(props: ProblemDisplayParams) {
         }
         return input;
       }),
+    });
+  };
+
+  // Handle adding a new problem input for this problem
+  const addProblemInput = () => {
+    setNewProblem({
+      ...newProblem,
+      problemInputs: [...newProblem.problemInputs, { name: 'name', type: ProblemIOType.Integer }],
+    });
+  };
+
+  // Handle deleting a problem input for this problem
+  const deleteProblemInput = (index: number) => {
+    setNewProblem({
+      ...newProblem,
+      problemInputs: newProblem.problemInputs.filter((_, i) => index !== i),
     });
   };
 
@@ -78,6 +95,7 @@ function ProblemDisplay(props: ProblemDisplayParams) {
       })}
 
       <MediumText>Problem Inputs:</MediumText>
+      <SmallButton onClick={addProblemInput}>Add Input</SmallButton>
       {newProblem.problemInputs.map((input, index) => (
         <div>
           <Text bold>{`Input ${index + 1}`}</Text>
@@ -99,6 +117,7 @@ function ProblemDisplay(props: ProblemDisplayParams) {
               </ProblemIOTypeButton>
             );
           })}
+          <SmallButton onClick={() => deleteProblemInput(index)}>Delete Input</SmallButton>
         </div>
       ))}
 
@@ -115,7 +134,7 @@ function ProblemDisplay(props: ProblemDisplayParams) {
         );
       })}
 
-      <LargeInputButton value="Edit Problem" onClick={() => onClick(newProblem)} />
+      <LargeInputButton value={actionText} onClick={() => onClick(newProblem)} />
     </Content>
   );
 }

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -2,7 +2,9 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { deleteProblem, Problem, ProblemIOType } from '../../api/Problem';
-import { ConsoleTextArea, LargeInputButton, TextInput } from '../core/Input';
+import {
+  ConsoleTextArea, LargeInputButton, TextInput, CheckboxInput,
+} from '../core/Input';
 import Difficulty from '../../api/Difficulty';
 import { DifficultyButton, ProblemIOTypeButton, SmallButton } from '../core/Button';
 import { MediumText, Text } from '../core/Text';
@@ -91,7 +93,8 @@ function ProblemDisplay(props: ProblemDisplayParams) {
   };
 
   // Handle updating of test case
-  const handleTestCaseChange = (index: number, input: string, output: string) => {
+  const handleTestCaseChange = (index: number, input: string,
+    output: string, hidden: boolean, explanation: string) => {
     setNewProblem({
       ...newProblem,
       testCases: newProblem.testCases.map((testCase, i) => {
@@ -99,8 +102,8 @@ function ProblemDisplay(props: ProblemDisplayParams) {
           return {
             input,
             output,
-            hidden: false,
-            explanation: '',
+            hidden,
+            explanation,
           };
         }
         return testCase;
@@ -207,17 +210,49 @@ function ProblemDisplay(props: ProblemDisplayParams) {
             {newProblem.testCases.map((testCase, index) => (
               <div>
                 <Text bold>{`Test Case ${index + 1}`}</Text>
+                <Text>Input</Text>
                 <ConsoleTextArea
                   value={newProblem.testCases[index].input}
-                  onChange={(e) => handleTestCaseChange(index,
-                    e.target.value, newProblem.testCases[index].output)}
+                  onChange={(e) => {
+                    const current = newProblem.testCases[index];
+                    handleTestCaseChange(index, e.target.value,
+                      current.output, current.hidden, current.explanation);
+                  }}
                 />
                 <br />
+                <Text>Output</Text>
                 <TextInput
                   value={newProblem.testCases[index].output}
-                  onChange={(e) => handleTestCaseChange(index,
-                    newProblem.testCases[index].input, e.target.value)}
+                  onChange={(e) => {
+                    const current = newProblem.testCases[index];
+                    handleTestCaseChange(index, current.input, e.target.value,
+                      current.hidden, current.explanation);
+                  }}
                 />
+
+                <Text>Explanation</Text>
+                <TextInput
+                  value={newProblem.testCases[index].explanation}
+                  onChange={(e) => {
+                    const current = newProblem.testCases[index];
+                    handleTestCaseChange(index, current.input, current.output,
+                      current.hidden, e.target.value);
+                  }}
+                />
+
+                <label htmlFor={`problem-hidden-${index}`}>
+                  Hidden
+                  <CheckboxInput
+                    id={`problem-hidden-${index}`}
+                    checked={newProblem.testCases[index].hidden}
+                    onChange={(e) => {
+                      const current = newProblem.testCases[index];
+                      handleTestCaseChange(index, current.input,
+                        current.output, e.target.checked, current.explanation);
+                    }}
+                  />
+                </label>
+
                 <SmallButton onClick={() => deleteTestCase(index)}>Delete Test Case</SmallButton>
               </div>
             ))}

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -160,7 +160,6 @@ function ProblemDisplay(props: ProblemDisplayParams) {
       })}
 
       <MediumText>Problem Inputs:</MediumText>
-      <SmallButton onClick={addProblemInput}>Add Input</SmallButton>
       {newProblem.problemInputs.map((input, index) => (
         <div>
           <Text bold>{`Input ${index + 1}`}</Text>
@@ -185,6 +184,7 @@ function ProblemDisplay(props: ProblemDisplayParams) {
           <SmallButton onClick={() => deleteProblemInput(index)}>Delete Input</SmallButton>
         </div>
       ))}
+      <SmallButton onClick={addProblemInput}>Add Input</SmallButton>
 
       <MediumText>Output Type:</MediumText>
       {Object.keys(ProblemIOType).map((key) => {
@@ -203,7 +203,6 @@ function ProblemDisplay(props: ProblemDisplayParams) {
         ? (
           <div>
             <MediumText>Test Cases:</MediumText>
-            <SmallButton onClick={addTestCase}>Add Test Case</SmallButton>
             {newProblem.testCases.map((testCase, index) => (
               <div>
                 <Text bold>{`Test Case ${index + 1}`}</Text>
@@ -220,6 +219,7 @@ function ProblemDisplay(props: ProblemDisplayParams) {
                 <SmallButton onClick={() => deleteTestCase(index)}>Delete Test Case</SmallButton>
               </div>
             ))}
+            <SmallButton onClick={addTestCase}>Add Test Case</SmallButton>
           </div>
         ) : null}
 

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { Problem } from '../../api/Problem';
+import { Problem, ProblemIOType } from '../../api/Problem';
 import { LargeInputButton, TextInput } from '../core/Input';
+import Difficulty from '../../api/Difficulty';
+import { DifficultyButton } from '../core/Button';
 
 const Content = styled.div`
   padding: 10px;
@@ -16,12 +18,13 @@ function ProblemDisplay(props: ProblemDisplayParams) {
   const { problem, onClick } = props;
   const [newProblem, setNewProblem] = useState<Problem>(problem);
 
+  //   difficulty: Difficulty,
+  //   testCases: TestCase[],
+  //   problemInputs: ProblemInput[],
+  //   outputType: ProblemIOType,
+
   const handleChange = (e: any) => {
     const { name, value } = e.target;
-    console.log({
-      ...newProblem,
-      [name]: value,
-    });
     setNewProblem({
       ...newProblem,
       [name]: value,
@@ -43,6 +46,35 @@ function ProblemDisplay(props: ProblemDisplayParams) {
         value={newProblem.description}
         onChange={handleChange}
       />
+
+      {Object.keys(Difficulty).map((key) => {
+        const difficulty = Difficulty[key as keyof typeof Difficulty];
+        if (difficulty !== Difficulty.Random) {
+          return (
+            <DifficultyButton
+              onClick={() => handleChange({ target: 'difficulty', value: difficulty })}
+              active={difficulty === problem.difficulty}
+              enabled
+            >
+              {key}
+            </DifficultyButton>
+          );
+        }
+        return null;
+      })}
+
+      {Object.keys(ProblemIOType).map((key) => {
+        const outputType = ProblemIOType[key as keyof typeof ProblemIOType];
+        return (
+          <DifficultyButton
+            onClick={() => handleChange({ target: 'outputType', value: outputType })}
+            active={outputType === problem.outputType}
+            enabled
+          >
+            {key}
+          </DifficultyButton>
+        );
+      })}
 
       <LargeInputButton value="Edit Problem" onClick={() => onClick(newProblem)} />
     </Content>

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -1,10 +1,13 @@
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
-import { Problem, ProblemIOType } from '../../api/Problem';
+import { deleteProblem, Problem, ProblemIOType } from '../../api/Problem';
 import { LargeInputButton, TextInput } from '../core/Input';
 import Difficulty from '../../api/Difficulty';
 import { DifficultyButton, ProblemIOTypeButton, SmallButton } from '../core/Button';
 import { MediumText, Text } from '../core/Text';
+import Loading from '../core/Loading';
+import ErrorMessage from '../core/Error';
 
 const Content = styled.div`
   padding: 10px;
@@ -21,7 +24,30 @@ function ProblemDisplay(props: ProblemDisplayParams) {
   const {
     problem, onClick, actionText, editMode,
   } = props;
+
+  const history = useHistory();
   const [newProblem, setNewProblem] = useState<Problem>(problem);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const deleteProblemFunc = () => {
+    if (!window.confirm('Are you sure you want to delete this problem?')) {
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    deleteProblem(newProblem.problemId)
+      .then(() => {
+        setLoading(false);
+        history.replace('/problems/all');
+      })
+      .catch((err) => {
+        setError(err.message);
+        setLoading(false);
+      });
+  };
 
   // Handle updating of normal text fields
   const handleChange = (e: any) => {
@@ -198,6 +224,10 @@ function ProblemDisplay(props: ProblemDisplayParams) {
         ) : null}
 
       <LargeInputButton value={actionText} onClick={() => onClick(newProblem)} />
+      {editMode ? <LargeInputButton value="Delete Problem" onClick={deleteProblemFunc} /> : null}
+
+      {loading ? <Loading /> : null}
+      {error ? <ErrorMessage message={error} /> : null}
     </Content>
   );
 }

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -61,6 +61,42 @@ function ProblemDisplay(props: ProblemDisplayParams) {
     });
   };
 
+  // Handle updating of test case
+  const handleTestCaseChange = (index: number, input: string, output: string) => {
+    setNewProblem({
+      ...newProblem,
+      testCases: newProblem.testCases.map((testCase, i) => {
+        if (index === i) {
+          return {
+            input,
+            output,
+            hidden: false,
+            explanation: '',
+          };
+        }
+        return testCase;
+      }),
+    });
+  };
+
+  // Handle adding a new test case for this problem
+  const addTestCase = () => {
+    setNewProblem({
+      ...newProblem,
+      testCases: [...newProblem.testCases, {
+        input: '0', output: '0', hidden: false, explanation: '',
+      }],
+    });
+  };
+
+  // Handle deleting a test case for this problem
+  const deleteTestCase = (index: number) => {
+    setNewProblem({
+      ...newProblem,
+      problemInputs: newProblem.problemInputs.filter((_, i) => index !== i),
+    });
+  };
+
   return (
     <Content>
       <MediumText>Name:</MediumText>
@@ -133,6 +169,25 @@ function ProblemDisplay(props: ProblemDisplayParams) {
           </ProblemIOTypeButton>
         );
       })}
+
+      <MediumText>Test Cases:</MediumText>
+      <SmallButton onClick={addTestCase}>Add Test Case</SmallButton>
+      {newProblem.testCases.map((testCase, index) => (
+        <div>
+          <Text bold>{`Test Case ${index + 1}`}</Text>
+          <TextInput
+            value={newProblem.testCases[index].input}
+            onChange={(e) => handleTestCaseChange(index,
+              e.target.value, newProblem.testCases[index].input)}
+          />
+          <TextInput
+            value={newProblem.testCases[index].input}
+            onChange={(e) => handleTestCaseChange(index,
+              e.target.value, newProblem.testCases[index].input)}
+          />
+          <SmallButton onClick={() => deleteTestCase(index)}>Delete Test Case</SmallButton>
+        </div>
+      ))}
 
       <LargeInputButton value={actionText} onClick={() => onClick(newProblem)} />
     </Content>

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Problem } from '../../api/Problem';
-import { Input } from '../core/Input';
+import { TextInput } from '../core/Input';
 
 const Content = styled.div`
   padding: 10px;
@@ -16,11 +16,14 @@ function ProblemDisplay(props: ProblemDisplayParams) {
 
   return (
     <Content>
-      <Input
+      Name:
+      <TextInput
         value={problem.name}
         onChange={(e) => { problem.name = e.target.value; }}
       />
-      <Input
+
+      Description:
+      <TextInput
         value={problem.description}
         onChange={(e) => { problem.description = e.target.value; }}
       />

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -19,11 +19,7 @@ function ProblemDisplay(props: ProblemDisplayParams) {
   const { problem, onClick } = props;
   const [newProblem, setNewProblem] = useState<Problem>(problem);
 
-  //   difficulty: Difficulty,
-  //   testCases: TestCase[],
-  //   problemInputs: ProblemInput[],
-  //   outputType: ProblemIOType,
-
+  // Handle updating of normal text fields
   const handleChange = (e: any) => {
     const { name, value } = e.target;
     setNewProblem({
@@ -32,10 +28,20 @@ function ProblemDisplay(props: ProblemDisplayParams) {
     });
   };
 
+  // Handle updating of enum-type fields
   const handleEnumChange = (name: string, value: any) => handleChange({ target: { name, value } });
 
+  // Handle updating of problem inputs
   const handleInputChange = (index: number, name: string, type: ProblemIOType) => {
-    return 0;
+    setNewProblem({
+      ...newProblem,
+      problemInputs: newProblem.problemInputs.map((input, i) => {
+        if (index === i) {
+          return { name, type };
+        }
+        return input;
+      }),
+    });
   };
 
   return (
@@ -71,12 +77,12 @@ function ProblemDisplay(props: ProblemDisplayParams) {
         return null;
       })}
 
+      <MediumText>Problem Inputs:</MediumText>
       {newProblem.problemInputs.map((input, index) => (
         <div>
-          <Text>{`Input ${index + 1}`}</Text>
+          <Text bold>{`Input ${index + 1}`}</Text>
           <TextInput
-            name="name"
-            value={newProblem.name}
+            value={newProblem.problemInputs[index].name}
             onChange={(e) => handleInputChange(index,
               e.target.value, newProblem.problemInputs[index].type)}
           />

--- a/frontend/src/views/AllProblemsPage.tsx
+++ b/frontend/src/views/AllProblemsPage.tsx
@@ -1,9 +1,36 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { getProblems, Problem } from '../api/Problem';
+import { LargeText } from '../components/core/Text';
+import ErrorMessage from '../components/core/Error';
+import Loading from '../components/core/Loading';
+import ProblemCard from '../components/card/ProblemCard';
 
 function AllProblemsPage() {
+  const [problems, setProblems] = useState<Problem[] | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getProblems()
+      .then((res) => {
+        setProblems(res);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message);
+        setLoading(false);
+      });
+  }, []);
+
   return (
     <div>
-      stuff
+      <LargeText>View All Problems</LargeText>
+      { error ? <ErrorMessage message={error} /> : null }
+      { loading ? <Loading /> : null }
+
+      {problems?.forEach((problem) =>
+        <ProblemCard problem={problem} />
+      )}
     </div>
   );
 }

--- a/frontend/src/views/AllProblemsPage.tsx
+++ b/frontend/src/views/AllProblemsPage.tsx
@@ -6,6 +6,7 @@ import { LargeText } from '../components/core/Text';
 import ErrorMessage from '../components/core/Error';
 import Loading from '../components/core/Loading';
 import ProblemCard from '../components/card/ProblemCard';
+import { TextLink } from '../components/core/Link';
 
 const Content = styled.div`
   padding: 0 20%;
@@ -36,6 +37,7 @@ function AllProblemsPage() {
   return (
     <Content>
       <LargeText>View All Problems</LargeText>
+      <TextLink to="/problem/create">Create new problem</TextLink>
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }
 

--- a/frontend/src/views/AllProblemsPage.tsx
+++ b/frontend/src/views/AllProblemsPage.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function AllProblemsPage() {
+  return (
+    <div>
+      stuff
+    </div>
+  );
+}
+
+export default AllProblemsPage;

--- a/frontend/src/views/AllProblemsPage.tsx
+++ b/frontend/src/views/AllProblemsPage.tsx
@@ -33,7 +33,7 @@ function AllProblemsPage() {
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }
 
-      {problems?.forEach((problem) => <ProblemCard problem={problem} />)}
+      {problems?.map((problem) => <ProblemCard problem={problem} />)}
     </Content>
   );
 }

--- a/frontend/src/views/AllProblemsPage.tsx
+++ b/frontend/src/views/AllProblemsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { getProblems, Problem } from '../api/Problem';
 import { LargeText } from '../components/core/Text';
@@ -11,6 +12,7 @@ const Content = styled.div`
 `;
 
 function AllProblemsPage() {
+  const history = useHistory();
   const [problems, setProblems] = useState<Problem[] | null>(null);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
@@ -27,13 +29,17 @@ function AllProblemsPage() {
       });
   }, []);
 
+  const redirect = (problemId: string) => {
+    history.push(`/problem/${problemId}`);
+  };
+
   return (
     <Content>
       <LargeText>View All Problems</LargeText>
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }
 
-      {problems?.map((problem) => <ProblemCard problem={problem} />)}
+      {problems?.map((problem) => <ProblemCard problem={problem} onClick={redirect} />)}
     </Content>
   );
 }

--- a/frontend/src/views/AllProblemsPage.tsx
+++ b/frontend/src/views/AllProblemsPage.tsx
@@ -1,9 +1,14 @@
 import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
 import { getProblems, Problem } from '../api/Problem';
 import { LargeText } from '../components/core/Text';
 import ErrorMessage from '../components/core/Error';
 import Loading from '../components/core/Loading';
 import ProblemCard from '../components/card/ProblemCard';
+
+const Content = styled.div`
+  padding: 0 20%;
+`;
 
 function AllProblemsPage() {
   const [problems, setProblems] = useState<Problem[] | null>(null);
@@ -23,15 +28,13 @@ function AllProblemsPage() {
   }, []);
 
   return (
-    <div>
+    <Content>
       <LargeText>View All Problems</LargeText>
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }
 
-      {problems?.forEach((problem) =>
-        <ProblemCard problem={problem} />
-      )}
-    </div>
+      {problems?.forEach((problem) => <ProblemCard problem={problem} />)}
+    </Content>
   );
 }
 

--- a/frontend/src/views/CreateProblemPage.tsx
+++ b/frontend/src/views/CreateProblemPage.tsx
@@ -7,6 +7,7 @@ import ErrorMessage from '../components/core/Error';
 import Loading from '../components/core/Loading';
 import ProblemDisplay from '../components/problem/ProblemDisplay';
 import Difficulty from '../api/Difficulty';
+import { TextLink } from '../components/core/Link';
 
 const Content = styled.div`
   padding: 0 20%;
@@ -48,6 +49,7 @@ function CreateProblemPage() {
   return (
     <Content>
       <LargeText>Create Problem</LargeText>
+      <TextLink to="/problems/all">Back to all problems</TextLink>
       <ProblemDisplay problem={problem!} onClick={handleSubmit} actionText="Create Problem" editMode={false} />
 
       { error ? <ErrorMessage message={error} /> : null }

--- a/frontend/src/views/CreateProblemPage.tsx
+++ b/frontend/src/views/CreateProblemPage.tsx
@@ -30,6 +30,7 @@ function CreateProblemPage() {
 
   const handleSubmit = (newProblem: Problem) => {
     setLoading(true);
+    setError('');
 
     createProblem(newProblem)
       .then((res) => {
@@ -47,10 +48,10 @@ function CreateProblemPage() {
   return (
     <Content>
       <LargeText>Create Problem</LargeText>
+      <ProblemDisplay problem={problem!} onClick={handleSubmit} />
+
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }
-
-      <ProblemDisplay problem={problem!} onClick={handleSubmit} />
     </Content>
   );
 }

--- a/frontend/src/views/CreateProblemPage.tsx
+++ b/frontend/src/views/CreateProblemPage.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { useHistory } from 'react-router-dom';
 import { createProblem, Problem, ProblemIOType } from '../api/Problem';
 import { LargeText } from '../components/core/Text';
 import ErrorMessage from '../components/core/Error';
 import Loading from '../components/core/Loading';
 import ProblemDisplay from '../components/problem/ProblemDisplay';
 import Difficulty from '../api/Difficulty';
-import { useHistory } from 'react-router-dom';
 
 const Content = styled.div`
   padding: 0 20%;

--- a/frontend/src/views/CreateProblemPage.tsx
+++ b/frontend/src/views/CreateProblemPage.tsx
@@ -26,7 +26,7 @@ function CreateProblemPage() {
   const history = useHistory();
   const [problem, setProblem] = useState<Problem>(firstProblem);
   const [error, setError] = useState('');
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = (newProblem: Problem) => {
     setLoading(true);
@@ -48,7 +48,7 @@ function CreateProblemPage() {
   return (
     <Content>
       <LargeText>Create Problem</LargeText>
-      <ProblemDisplay problem={problem!} onClick={handleSubmit} actionText="Create Problem" />
+      <ProblemDisplay problem={problem!} onClick={handleSubmit} actionText="Create Problem" editMode={false} />
 
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }

--- a/frontend/src/views/CreateProblemPage.tsx
+++ b/frontend/src/views/CreateProblemPage.tsx
@@ -1,10 +1,57 @@
-import React from 'react';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { createProblem, Problem, ProblemIOType } from '../api/Problem';
+import { LargeText } from '../components/core/Text';
+import ErrorMessage from '../components/core/Error';
+import Loading from '../components/core/Loading';
+import ProblemDisplay from '../components/problem/ProblemDisplay';
+import Difficulty from '../api/Difficulty';
+import { useHistory } from 'react-router-dom';
+
+const Content = styled.div`
+  padding: 0 20%;
+`;
 
 function CreateProblemPage() {
+  const firstProblem = {
+    problemId: '',
+    name: 'Name',
+    description: 'Description',
+    difficulty: Difficulty.Easy,
+    testCases: [],
+    problemInputs: [],
+    outputType: ProblemIOType.Integer,
+  };
+
+  const history = useHistory();
+  const [problem, setProblem] = useState<Problem>(firstProblem);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const handleSubmit = (newProblem: Problem) => {
+    setLoading(true);
+
+    createProblem(newProblem)
+      .then((res) => {
+        setProblem(res);
+        setLoading(false);
+
+        history.replace(`/problem/${res.problemId}`);
+      })
+      .catch((err) => {
+        setError(err.message);
+        setLoading(false);
+      });
+  };
+
   return (
-    <div>
-      stuff
-    </div>
+    <Content>
+      <LargeText>Create Problem</LargeText>
+      { error ? <ErrorMessage message={error} /> : null }
+      { loading ? <Loading /> : null }
+
+      <ProblemDisplay problem={problem!} onClick={handleSubmit} />
+    </Content>
   );
 }
 

--- a/frontend/src/views/CreateProblemPage.tsx
+++ b/frontend/src/views/CreateProblemPage.tsx
@@ -48,7 +48,7 @@ function CreateProblemPage() {
   return (
     <Content>
       <LargeText>Create Problem</LargeText>
-      <ProblemDisplay problem={problem!} onClick={handleSubmit} />
+      <ProblemDisplay problem={problem!} onClick={handleSubmit} actionText="Create Problem" />
 
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }

--- a/frontend/src/views/CreateProblemPage.tsx
+++ b/frontend/src/views/CreateProblemPage.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function CreateProblemPage() {
+  return (
+    <div>
+      stuff
+    </div>
+  );
+}
+
+export default CreateProblemPage;

--- a/frontend/src/views/ProblemPage.tsx
+++ b/frontend/src/views/ProblemPage.tsx
@@ -60,7 +60,7 @@ function ProblemPage() {
   return (
     <Content>
       <LargeText>Edit Problem</LargeText>
-      <ProblemDisplay problem={problem!} onClick={handleEdit} actionText="Edit Problem" />
+      <ProblemDisplay problem={problem!} onClick={handleEdit} actionText="Edit Problem" editMode />
 
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }

--- a/frontend/src/views/ProblemPage.tsx
+++ b/frontend/src/views/ProblemPage.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function ProblemPage() {
+  return (
+    <div>
+      stuff
+    </div>
+  );
+}
+
+export default ProblemPage;

--- a/frontend/src/views/ProblemPage.tsx
+++ b/frontend/src/views/ProblemPage.tsx
@@ -7,6 +7,7 @@ import { LargeText } from '../components/core/Text';
 import ErrorMessage from '../components/core/Error';
 import Loading from '../components/core/Loading';
 import ProblemDisplay from '../components/problem/ProblemDisplay';
+import { TextLink } from '../components/core/Link';
 
 const Content = styled.div`
   padding: 0 20%;
@@ -60,7 +61,8 @@ function ProblemPage() {
   return (
     <Content>
       <LargeText>Edit Problem</LargeText>
-      <ProblemDisplay problem={problem!} onClick={handleEdit} actionText="Edit Problem" editMode />
+      <TextLink to="/problems/all">Back to all problems</TextLink>
+      <ProblemDisplay problem={problem!} onClick={handleEdit} actionText="Save" editMode />
 
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }

--- a/frontend/src/views/ProblemPage.tsx
+++ b/frontend/src/views/ProblemPage.tsx
@@ -44,6 +44,7 @@ function ProblemPage() {
 
   const handleEdit = (newProblem: Problem) => {
     setLoading(true);
+    setError('');
 
     editProblem(newProblem.problemId, newProblem)
       .then((res) => {
@@ -59,10 +60,10 @@ function ProblemPage() {
   return (
     <Content>
       <LargeText>Edit Problem</LargeText>
+      <ProblemDisplay problem={problem!} onClick={handleEdit} />
+
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }
-
-      <ProblemDisplay problem={problem!} onClick={handleEdit} />
     </Content>
   );
 }

--- a/frontend/src/views/ProblemPage.tsx
+++ b/frontend/src/views/ProblemPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useParams } from 'react-router-dom';
 import { getSingleProblem, Problem } from '../api/Problem';
@@ -23,27 +23,25 @@ function ProblemPage() {
 
   const params = useParams<ProblemParams>();
 
-  if (!params.id) {
-    return <NotFound />;
-  }
+  useEffect(() => {
+    getSingleProblem(params.id)
+      .then((res) => {
+        setProblem(res);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message);
+        setLoading(false);
+      });
+  }, []);
 
-  getSingleProblem(params.id)
-    .then((res) => {
-      setProblem(res);
-      setLoading(false);
-    })
-    .catch((err) => {
-      setError(err.message);
-      setLoading(false);
-    });
-
-  if (!problem) {
+  if (!problem && !loading) {
     return <NotFound />;
   }
 
   return (
     <Content>
-      <LargeText>Problem</LargeText>
+      <LargeText>Edit Problem</LargeText>
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }
 

--- a/frontend/src/views/ProblemPage.tsx
+++ b/frontend/src/views/ProblemPage.tsx
@@ -34,7 +34,7 @@ function ProblemPage() {
         setError(err.message);
         setLoading(false);
       });
-  }, []);
+  }, [params]);
 
   if (!problem) {
     if (loading) {

--- a/frontend/src/views/ProblemPage.tsx
+++ b/frontend/src/views/ProblemPage.tsx
@@ -60,7 +60,7 @@ function ProblemPage() {
   return (
     <Content>
       <LargeText>Edit Problem</LargeText>
-      <ProblemDisplay problem={problem!} onClick={handleEdit} />
+      <ProblemDisplay problem={problem!} onClick={handleEdit} actionText="Edit Problem" />
 
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }

--- a/frontend/src/views/ProblemPage.tsx
+++ b/frontend/src/views/ProblemPage.tsx
@@ -35,7 +35,10 @@ function ProblemPage() {
       });
   }, []);
 
-  if (!problem && !loading) {
+  if (!problem) {
+    if (loading) {
+      return <Loading />;
+    }
     return <NotFound />;
   }
 

--- a/frontend/src/views/ProblemPage.tsx
+++ b/frontend/src/views/ProblemPage.tsx
@@ -1,10 +1,54 @@
-import React from 'react';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useParams } from 'react-router-dom';
+import { getSingleProblem, Problem } from '../api/Problem';
+import NotFound from './NotFound';
+import { LargeText } from '../components/core/Text';
+import ErrorMessage from '../components/core/Error';
+import Loading from '../components/core/Loading';
+import ProblemDisplay from '../components/problem/ProblemDisplay';
+
+const Content = styled.div`
+  padding: 0 20%;
+`;
+
+type ProblemParams = {
+  id: string,
+};
 
 function ProblemPage() {
+  const [problem, setProblem] = useState<Problem | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const params = useParams<ProblemParams>();
+
+  if (!params.id) {
+    return <NotFound />;
+  }
+
+  getSingleProblem(params.id)
+    .then((res) => {
+      setProblem(res);
+      setLoading(false);
+    })
+    .catch((err) => {
+      setError(err.message);
+      setLoading(false);
+    });
+
+  if (!problem) {
+    return <NotFound />;
+  }
+
   return (
-    <div>
-      stuff
-    </div>
+    <Content>
+      <LargeText>Problem</LargeText>
+      { error ? <ErrorMessage message={error} /> : null }
+      { loading ? <Loading /> : null }
+
+      <ProblemDisplay problem={problem!} />
+    </Content>
   );
 }
 

--- a/frontend/src/views/ProblemPage.tsx
+++ b/frontend/src/views/ProblemPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useParams } from 'react-router-dom';
-import { getSingleProblem, Problem } from '../api/Problem';
+import { editProblem, getSingleProblem, Problem } from '../api/Problem';
 import NotFound from './NotFound';
 import { LargeText } from '../components/core/Text';
 import ErrorMessage from '../components/core/Error';
@@ -39,13 +39,27 @@ function ProblemPage() {
     return <NotFound />;
   }
 
+  const handleEdit = (newProblem: Problem) => {
+    setLoading(true);
+
+    editProblem(newProblem.problemId, newProblem)
+      .then((res) => {
+        setProblem(res);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message);
+        setLoading(false);
+      });
+  };
+
   return (
     <Content>
       <LargeText>Edit Problem</LargeText>
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }
 
-      <ProblemDisplay problem={problem!} />
+      <ProblemDisplay problem={problem!} onClick={handleEdit} />
     </Content>
   );
 }

--- a/src/main/java/com/rocketden/main/service/ProblemService.java
+++ b/src/main/java/com/rocketden/main/service/ProblemService.java
@@ -46,6 +46,7 @@ public class ProblemService {
 
     public ProblemDto createProblem(CreateProblemRequest request) {
         if (request.getName() == null || request.getDescription() == null
+                || request.getName().isEmpty() || request.getDescription().isEmpty()
                 || request.getDifficulty() == null
                 || request.getProblemInputs() == null
                 || request.getOutputType() == null) {
@@ -95,6 +96,8 @@ public class ProblemService {
 
         if (updatedProblem == null || updatedProblem.getName() == null
                 || updatedProblem.getDescription() == null
+                || updatedProblem.getName().isEmpty()
+                || updatedProblem.getDescription().isEmpty()
                 || updatedProblem.getDifficulty() == null
                 || updatedProblem.getProblemInputs() == null
                 || updatedProblem.getTestCases() == null
@@ -241,7 +244,7 @@ public class ProblemService {
 
     // Check to make sure test case inputs and outputs are Gson-parsable
     protected void validateInputsGsonParseable(String input, List<ProblemInputDto> types) {
-        if (input == null) {
+        if (input == null || input.isEmpty()) {
             throw new ApiException(ProblemError.INVALID_INPUT);
         }
 

--- a/src/main/java/com/rocketden/main/service/ProblemService.java
+++ b/src/main/java/com/rocketden/main/service/ProblemService.java
@@ -244,7 +244,7 @@ public class ProblemService {
 
     // Check to make sure test case inputs and outputs are Gson-parsable
     protected void validateInputsGsonParseable(String input, List<ProblemInputDto> types) {
-        if (input == null || input.isEmpty()) {
+        if (input == null) {
             throw new ApiException(ProblemError.INVALID_INPUT);
         }
 
@@ -270,7 +270,13 @@ public class ProblemService {
         }
 
         try {
-            gson.fromJson(input, type.getClassType());
+            Object result = gson.fromJson(input, type.getClassType());
+
+            // Trigger catch block to return invalid input error
+            if (result == null) {
+                throw new Exception();
+            }
+
         } catch (Exception e) {
             throw new ApiException(ProblemError.INVALID_INPUT);
         }

--- a/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
@@ -571,6 +571,11 @@ public class ProblemServiceTests {
 
         assertEquals(ProblemError.INVALID_INPUT, exception.getError());
 
+        exception = assertThrows(ApiException.class, () ->
+                problemService.validateInputsGsonParseable("true\n\n5.0", inputs));
+
+        assertEquals(ProblemError.INVALID_INPUT, exception.getError());
+
         inputs.add(new ProblemInputDto("", ProblemIOType.ARRAY_STRING));
         exception = assertThrows(ApiException.class, () ->
                 problemService.validateInputsGsonParseable("true\n[a]\n3.0\n[]", inputs));


### PR DESCRIPTION
### List of Changes:

* Update problem types on frontend
* Add axios routes to call problem CRUD endpoints
* Create a page for viewing all problems (`/problems/all`)
* Create a page for creating, editing, and deleting a problem (`/problem/create` and `/problem/{problemId}`
* Add additional checks for empty strings on backend
* Add navigation between problem pages 

### Notes:

* As of now, the problem pages have no authentication protocols, so anyone can edit them (as a result there's no button from the home page to access those pages, you need a direct URL)
* The `ProblemDisplay.tsx` file has lots of fancy code for updating the problem state due to React's recommendation to [never directly modify state](https://stackoverflow.com/questions/37755997/why-cant-i-directly-modify-a-components-state-really)
* The problem page right now looks hideous haha - preferably we could make a quick mockup/proposed design for that page and make it look nicer before merging (right now it's too uncompact and makes it hard to actually edit/create problems)

### Screencast and Images:

[Screencast](https://www.loom.com/share/10cc8ff1d37448ada719d00a778fe1f4) (unpictured is a confirmation popup before deleting and a not found page when the URL's problemId can't be found)

All problems page:
<img width="1641" alt="All problems page" src="https://user-images.githubusercontent.com/24768574/107582091-e0cd5780-6bad-11eb-8ce8-29b9c6f9c25e.png">

Problem page (part 1, zoomed out):
<img width="1229" alt="Problem page part 1" src="https://user-images.githubusercontent.com/24768574/107582094-e32fb180-6bad-11eb-9756-dfa0f90dcffe.png">

Problem page (part 2, zoomed out):
<img width="1174" alt="Problem page part 2" src="https://user-images.githubusercontent.com/24768574/107582098-e3c84800-6bad-11eb-9149-e55beaf82c55.png">

