### PR TITLE
Integrate main to use updated tester response data

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3534,9 +3534,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001117",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001117.tgz",
-      "integrity": "sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q=="
+      "version": "1.0.30001190",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001190.tgz",
+      "integrity": "sha512-62KVw474IK8E+bACBYhRS0/L6o/1oeAVkpF2WetjV58S5vkzNh0/Rz3lD8D4YCbOTqi0/aD4X3LtoP7V5xnuAg=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/frontend/src/api/Game.ts
+++ b/frontend/src/api/Game.ts
@@ -10,7 +10,7 @@ export type Player = {
   user: User,
   code: string,
   language: string,
-  submissions: SubmissionResult[],
+  submissions: Submission[],
   solved: boolean,
   color: Color,
 };
@@ -46,10 +46,21 @@ export type SubmitSolutionParams = {
 };
 
 export type SubmissionResult = {
+  console: string,
+  userOutput: string,
+  error: string,
+  correctOutput: string,
+  correct: boolean,
+};
+
+export type Submission = {
   code: string,
   language: string,
+  results: SubmissionResult[],
   numCorrect: number,
   numTestCases: number,
+  runtime: number,
+  compilationError: string,
   startTime: string,
 };
 
@@ -76,14 +87,14 @@ export const getGame = (roomId: string):
   });
 
 export const runSolution = (roomId: string, params: RunSolutionParams):
-  Promise<SubmissionResult> => axios.post<SubmissionResult>(routes.submitSolution(roomId), params)
+  Promise<Submission> => axios.post<Submission>(routes.submitSolution(roomId), params)
   .then((res) => res.data)
   .catch((err) => {
     throw axiosErrorHandler(err);
   });
 
 export const submitSolution = (roomId: string, params: SubmitSolutionParams):
-  Promise<SubmissionResult> => axios.post<SubmissionResult>(routes.submitSolution(roomId), params)
+  Promise<Submission> => axios.post<Submission>(routes.submitSolution(roomId), params)
   .then((res) => res.data)
   .catch((err) => {
     throw axiosErrorHandler(err);

--- a/frontend/src/api/Game.ts
+++ b/frontend/src/api/Game.ts
@@ -32,6 +32,13 @@ export type PlayAgainParams = {
   initiator: User,
 };
 
+export type RunSolutionParams = {
+  initiator: User,
+  input: string,
+  code: string,
+  language: string,
+};
+
 export type SubmitSolutionParams = {
   initiator: User,
   code: string,
@@ -63,6 +70,13 @@ export const startGame = (roomId: string, params: StartGameParams):
 
 export const getGame = (roomId: string):
   Promise<Game> => axios.get<Game>(routes.getGame(roomId))
+  .then((res) => res.data)
+  .catch((err) => {
+    throw axiosErrorHandler(err);
+  });
+
+export const runSolution = (roomId: string, params: RunSolutionParams):
+  Promise<SubmissionResult> => axios.post<SubmissionResult>(routes.submitSolution(roomId), params)
   .then((res) => res.data)
   .catch((err) => {
     throw axiosErrorHandler(err);

--- a/frontend/src/api/Game.ts
+++ b/frontend/src/api/Game.ts
@@ -49,7 +49,9 @@ export type SubmissionResult = {
   console: string,
   userOutput: string,
   error: string,
+  input: string,
   correctOutput: string,
+  hidden: boolean,
   correct: boolean,
 };
 

--- a/frontend/src/api/Game.ts
+++ b/frontend/src/api/Game.ts
@@ -55,6 +55,12 @@ export type SubmissionResult = {
   correct: boolean,
 };
 
+// Distinguish on frontend between tests and submissions.
+export enum SubmissionType {
+  Test = 'TEST',
+  Submit = 'SUBMIT',
+}
+
 export type Submission = {
   code: string,
   language: string,
@@ -64,6 +70,7 @@ export type Submission = {
   runtime: number,
   compilationError: string,
   startTime: string,
+  submissionType: SubmissionType,
 };
 
 const basePath = '/api/v1';

--- a/frontend/src/api/Game.ts
+++ b/frontend/src/api/Game.ts
@@ -70,6 +70,7 @@ const basePath = '/api/v1';
 const routes = {
   startGame: (roomId: string) => `${basePath}/rooms/${roomId}/start`,
   getGame: (roomId: string) => `${basePath}/games/${roomId}`,
+  runCode: (roomId: string) => `${basePath}/games/${roomId}/run-code`,
   submitSolution: (roomId: string) => `${basePath}/games/${roomId}/submission`,
   playAgain: (roomId: string) => `${basePath}/games/${roomId}/restart`,
 };
@@ -89,7 +90,7 @@ export const getGame = (roomId: string):
   });
 
 export const runSolution = (roomId: string, params: RunSolutionParams):
-  Promise<Submission> => axios.post<Submission>(routes.submitSolution(roomId), params)
+  Promise<Submission> => axios.post<Submission>(routes.runCode(roomId), params)
   .then((res) => res.data)
   .catch((err) => {
     throw axiosErrorHandler(err);

--- a/frontend/src/api/Language.ts
+++ b/frontend/src/api/Language.ts
@@ -1,14 +1,14 @@
 enum Language {
   Python = 'PYTHON',
-  Ruby = 'RUBY',
-  Swift = 'SWIFT',
-  CPP = 'CPP',
-  PHP = 'PHP',
-  C = 'C',
+  // Ruby = 'RUBY',
+  // Swift = 'SWIFT',
+  // CPP = 'CPP',
+  // PHP = 'PHP',
+  // C = 'C',
   Java = 'JAVA',
-  JavaScript = 'JAVASCRIPT',
-  Rust = 'RUST',
-  Bash = 'BASH',
+  // JavaScript = 'JAVASCRIPT',
+  // Rust = 'RUST',
+  // Bash = 'BASH',
 }
 
 export const fromString = (key: string): Language => Language[key as keyof typeof Language];

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -95,4 +95,5 @@ export const SmallButton = styled(DefaultButton)`
   color: ${({ theme }) => theme.colors.white};
   background-color: ${({ theme }) => theme.colors.blue};
   padding: 0.5rem 1rem;
+  margin: 0.4rem;
 `;

--- a/frontend/src/components/game/Console.tsx
+++ b/frontend/src/components/game/Console.tsx
@@ -4,7 +4,7 @@ import { TestCase } from '../../api/Problem';
 import { Text } from '../core/Text';
 import { ConsoleTextArea } from '../core/Input';
 import { SmallButton } from '../core/Button';
-import { Submission } from '../../api/Game';
+import { Submission, SubmissionResult } from '../../api/Game';
 
 const Content = styled.div`
   height: 100%;
@@ -39,7 +39,40 @@ function Console(props: ConsoleProps) {
   }, [testCases]);
 
   useEffect(() => {
-    setOutput(submission ? `${submission.numCorrect} / ${submission.numTestCases} passed` : '');
+    if (submission) {
+      // Set the submission details in the output, a list joined by new line.
+      const outputList: string[] = [];
+
+      // Add submission correctness.
+      outputList.push(`${submission.numCorrect} / ${submission.numTestCases} passed`);
+
+      // If a compilation error exists, show that; otherwise, show results.
+      if (submission.compilationError) {
+        outputList.push(`Compilation error: ${submission.compilationError}`);
+      } else {
+        outputList.push(`Runtime: ${submission.runtime}`);
+        let resultIndex: number = 1;
+        submission.results.forEach((result: SubmissionResult) => {
+          outputList.push('');
+          outputList.push(`Result #${resultIndex}: ${result.correct ? 'Correct' : 'Incorrect'}`);
+
+          // Show the test case details, if not hidden.
+          if (result.hidden) {
+            outputList.push('This test case is hidden.');
+          } else {
+            outputList.push(`Input: ${result.input}`);
+            outputList.push(`User output: ${result.userOutput}`);
+            outputList.push(`Correct output: ${result.correctOutput}`);
+            outputList.push(`Console: ${result.console}`);
+            outputList.push(`Error: ${result.error}`);
+          }
+
+          resultIndex += 1;
+        });
+      }
+
+      setOutput(outputList.join('\n'));
+    }
   }, [submission]);
 
   return (

--- a/frontend/src/components/game/Console.tsx
+++ b/frontend/src/components/game/Console.tsx
@@ -15,6 +15,7 @@ const FixedContent = styled.div`
   position: absolute;
   top: 0;
   right: 0;
+  margin: 0.6rem;
 `;
 
 type ConsoleProps = {
@@ -45,8 +46,6 @@ function Console(props: ConsoleProps) {
     <Content>
       <FixedContent>
         <SmallButton onClick={() => onRun(input)}>Run Code</SmallButton>
-      </FixedContent>
-      <FixedContent>
         <SmallButton onClick={() => onSubmit()}>Submit</SmallButton>
       </FixedContent>
       <div>

--- a/frontend/src/components/game/Console.tsx
+++ b/frontend/src/components/game/Console.tsx
@@ -4,7 +4,7 @@ import { TestCase } from '../../api/Problem';
 import { Text } from '../core/Text';
 import { ConsoleTextArea } from '../core/Input';
 import { SmallButton } from '../core/Button';
-import { SubmissionResult } from '../../api/Game';
+import { Submission } from '../../api/Game';
 
 const Content = styled.div`
   height: 100%;
@@ -19,7 +19,7 @@ const FixedContent = styled.div`
 
 type ConsoleProps = {
   testCases: TestCase[],
-  submission: SubmissionResult | null,
+  submission: Submission | null,
   onRun: (input: string) => void,
   onSubmit: () => void,
 };

--- a/frontend/src/components/game/Console.tsx
+++ b/frontend/src/components/game/Console.tsx
@@ -4,7 +4,7 @@ import { TestCase } from '../../api/Problem';
 import { Text } from '../core/Text';
 import { ConsoleTextArea } from '../core/Input';
 import { SmallButton } from '../core/Button';
-import { Submission, SubmissionResult } from '../../api/Game';
+import { Submission, SubmissionResult, SubmissionType } from '../../api/Game';
 
 const Content = styled.div`
   height: 100%;
@@ -44,7 +44,9 @@ function Console(props: ConsoleProps) {
       const outputList: string[] = [];
 
       // Add submission correctness.
-      outputList.push(`${submission.numCorrect} / ${submission.numTestCases} passed`);
+      if (submission.submissionType === SubmissionType.Submit) {
+        outputList.push(`${submission.numCorrect} / ${submission.numTestCases} passed`);
+      }
 
       // If a compilation error exists, show that; otherwise, show results.
       if (submission.compilationError) {
@@ -62,7 +64,11 @@ function Console(props: ConsoleProps) {
           } else {
             outputList.push(`Input: ${result.input}`);
             outputList.push(`User output: ${result.userOutput}`);
-            outputList.push(`Correct output: ${result.correctOutput}`);
+
+            // Only show correct output if type was 'submit'.
+            if (submission.submissionType === SubmissionType.Submit) {
+              outputList.push(`Correct output: ${result.correctOutput}`);
+            }
             outputList.push(`Console: ${result.console}`);
             outputList.push(`Error: ${result.error}`);
           }

--- a/frontend/src/components/game/Console.tsx
+++ b/frontend/src/components/game/Console.tsx
@@ -55,8 +55,11 @@ function Console(props: ConsoleProps) {
         outputList.push(`Runtime: ${submission.runtime}`);
         let resultIndex: number = 1;
         submission.results.forEach((result: SubmissionResult) => {
-          outputList.push('');
-          outputList.push(`Result #${resultIndex}: ${result.correct ? 'Correct' : 'Incorrect'}`);
+          // Only show newline, result #, and correctness if type was 'submit'.
+          if (submission.submissionType === SubmissionType.Submit) {
+            outputList.push('');
+            outputList.push(`Result #${resultIndex}: ${result.correct ? 'Correct' : 'Incorrect'}`);
+          }
 
           // Show the test case details, if not hidden.
           if (result.hidden) {

--- a/frontend/src/components/game/Console.tsx
+++ b/frontend/src/components/game/Console.tsx
@@ -21,6 +21,7 @@ type ConsoleProps = {
   testCases: TestCase[],
   submission: SubmissionResult | null,
   onRun: (input: string) => void,
+  onSubmit: () => void,
 };
 
 // This function refreshes the width of Monaco editor upon change in size
@@ -28,7 +29,9 @@ function Console(props: ConsoleProps) {
   const [input, setInput] = useState('');
   const [output, setOutput] = useState('');
 
-  const { testCases, submission, onRun } = props;
+  const {
+    testCases, submission, onRun, onSubmit,
+  } = props;
 
   useEffect(() => {
     setInput(testCases?.length ? testCases[0].input : '');
@@ -42,6 +45,9 @@ function Console(props: ConsoleProps) {
     <Content>
       <FixedContent>
         <SmallButton onClick={() => onRun(input)}>Run Code</SmallButton>
+      </FixedContent>
+      <FixedContent>
+        <SmallButton onClick={() => onSubmit()}>Submit</SmallButton>
       </FixedContent>
       <div>
         <Text bold>Input</Text>

--- a/frontend/src/components/game/Editor.tsx
+++ b/frontend/src/components/game/Editor.tsx
@@ -6,6 +6,7 @@ import { DefaultCodeType } from '../../api/Problem';
 
 type EditorProps = {
   onLanguageChange: (language: string) => void,
+  onCodeChange: (code: string) => void,
   codeMap: DefaultCodeType | null,
 };
 
@@ -18,7 +19,7 @@ function ResizableMonacoEditor(props: EditorProps) {
   const [currentLanguage, setCurrentLanguage] = useState<Language>(Language.Python);
   const [codeEditor, setCodeEditor] = useState<any>(null);
 
-  const { onLanguageChange, codeMap } = props;
+  const { onLanguageChange, onCodeChange, codeMap } = props;
 
   const handleEditorDidMount = (editor: any) => {
     setCodeEditor(editor);
@@ -63,6 +64,7 @@ function ResizableMonacoEditor(props: EditorProps) {
       <MonacoEditor
         height="100%"
         editorDidMount={handleEditorDidMount}
+        onChange={() => onCodeChange(codeEditor.getValue())}
         language={languageToEditorLanguage(currentLanguage)}
         defaultValue="Loading..."
       />

--- a/frontend/src/components/game/GameNotificationContainer.tsx
+++ b/frontend/src/components/game/GameNotificationContainer.tsx
@@ -26,8 +26,7 @@ const GameNotificationBox = styled.div`
 const notificationToString = (notification: GameNotification): string => {
   switch (notification.notificationType) {
     case NotificationType.SubmitCorrect: {
-      return `${notification.initiator.nickname} just submitted correctly
-        ${notification.content ? `, taking ${notification.content} place` : ''}.`;
+      return `${notification.initiator.nickname} just submitted correctly${notification.content ? `, taking ${notification.content} place` : ''}.`;
     }
     case NotificationType.SubmitIncorrect: {
       return `${notification.initiator.nickname} just submitted incorrectly.`;

--- a/frontend/src/components/game/GameNotificationContainer.tsx
+++ b/frontend/src/components/game/GameNotificationContainer.tsx
@@ -27,7 +27,7 @@ const notificationToString = (notification: GameNotification): string => {
   switch (notification.notificationType) {
     case NotificationType.SubmitCorrect: {
       return `${notification.initiator.nickname} just submitted correctly
-        ${notification.content ? `, taking ${notification.content} place, ` : ''}.`;
+        ${notification.content ? `, taking ${notification.content} place` : ''}.`;
     }
     case NotificationType.SubmitIncorrect: {
       return `${notification.initiator.nickname} just submitted incorrectly.`;

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -20,7 +20,7 @@ import { User } from '../api/User';
 import { GameNotification, NotificationType } from '../api/GameNotification';
 import Difficulty from '../api/Difficulty';
 import {
-  Game, getGame, Player, SubmissionResult, submitSolution,
+  Game, getGame, Player, SubmissionResult, submitSolution, runSolution,
 } from '../api/Game';
 import LeaderboardCard from '../components/card/LeaderboardCard';
 import GameTimerContainer from '../components/game/GameTimerContainer';
@@ -202,7 +202,30 @@ function GamePage() {
   };
 
   // Callback when user runs code against custom test case
-  const runSolution = () => {
+  const runCode = (input: string) => {
+    setLoading(true);
+    setError('');
+    const request = {
+      initiator: currentUser!,
+      input,
+      code: currentCode,
+      language: currentLanguage,
+    };
+
+    runSolution(roomId, request)
+      .then((res) => {
+        setLoading(false);
+        setSubmission(res);
+        checkSendTestCorrectNotification(res);
+      })
+      .catch((err) => {
+        setLoading(false);
+        setError(err.message);
+      });
+  };
+
+  // Callback when user runs code against custom test case
+  const submitCode = () => {
     setLoading(true);
     setError('');
     const request = {
@@ -316,7 +339,8 @@ function GamePage() {
               <Console
                 testCases={problems[0]?.testCases}
                 submission={submission}
-                onRun={runSolution}
+                onRun={runCode}
+                onSubmit={submitCode}
               />
             </Panel>
           </SplitterLayout>

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -20,7 +20,7 @@ import { User } from '../api/User';
 import { GameNotification, NotificationType } from '../api/GameNotification';
 import Difficulty from '../api/Difficulty';
 import {
-  Game, getGame, Player, Submission, submitSolution, runSolution,
+  Game, getGame, Player, Submission, submitSolution, runSolution, SubmissionType,
 } from '../api/Game';
 import LeaderboardCard from '../components/card/LeaderboardCard';
 import GameTimerContainer from '../components/game/GameTimerContainer';
@@ -230,6 +230,9 @@ function GamePage() {
     runSolution(roomId, request)
       .then((res) => {
         setLoading(false);
+
+        // Set the 'test' submission type to correctly display result.
+        res.submissionType = SubmissionType.Test;
         setSubmission(res);
         checkSendTestCorrectNotification(res);
       })
@@ -252,6 +255,9 @@ function GamePage() {
     submitSolution(roomId, request)
       .then((res) => {
         setLoading(false);
+
+        // Set the 'submit' submission type to correctly display result.
+        res.submissionType = SubmissionType.Submit;
         setSubmission(res);
         checkSendSolutionCorrectNotification(res);
       })

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -20,7 +20,7 @@ import { User } from '../api/User';
 import { GameNotification, NotificationType } from '../api/GameNotification';
 import Difficulty from '../api/Difficulty';
 import {
-  Game, getGame, Player, SubmissionResult, submitSolution, runSolution,
+  Game, getGame, Player, Submission, submitSolution, runSolution,
 } from '../api/Game';
 import LeaderboardCard from '../components/card/LeaderboardCard';
 import GameTimerContainer from '../components/game/GameTimerContainer';
@@ -42,7 +42,7 @@ function GamePage() {
   const history = useHistory();
   const location = useLocation<LocationState>();
 
-  const [submission, setSubmission] = useState<SubmissionResult | null>(null);
+  const [submission, setSubmission] = useState<Submission | null>(null);
 
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [roomId, setRoomId] = useState<string>('');
@@ -189,7 +189,7 @@ function GamePage() {
   };
 
   // Send notification if test submission is correct and currentUser is set.
-  const checkSendTestCorrectNotification = (submissionParam: SubmissionResult) => {
+  const checkSendTestCorrectNotification = (submissionParam: Submission) => {
     if (submissionParam.numCorrect === submissionParam.numTestCases && currentUser) {
       const notificationBody: string = JSON.stringify({
         initiator: currentUser,
@@ -202,7 +202,7 @@ function GamePage() {
   };
 
   // Send notification if solution is correct and currentUser is set.
-  const checkSendSolutionCorrectNotification = (submissionParam: SubmissionResult) => {
+  const checkSendSolutionCorrectNotification = (submissionParam: Submission) => {
     if (currentUser) {
       const notificationBody: string = JSON.stringify({
         initiator: currentUser,

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -210,7 +210,6 @@ function GamePage() {
         notificationType:
           (submissionParam.numCorrect === submissionParam.numTestCases)
             ? NotificationType.SubmitCorrect : NotificationType.SubmitIncorrect,
-        content: 'success',
       });
       send(routes(roomId).subscribe_notification, {}, notificationBody);
     }

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -56,6 +56,7 @@ function GamePage() {
   const [gameTimer, setGameTimer] = useState<GameTimer | null>(null);
   const [problems, setProblems] = useState<Problem[]>([]);
   const [currentLanguage, setCurrentLanguage] = useState('python');
+  const [currentCode, setCurrentCode] = useState('');
   const [timeUp, setTimeUp] = useState(false);
   const [allSolved, setAllSolved] = useState(false);
   const [defaultCodeList, setDefaultCodeList] = useState<DefaultCodeType[]>([]);
@@ -205,7 +206,8 @@ function GamePage() {
     setLoading(true);
     const request = {
       initiator: currentUser!,
-      code: input,
+      input,
+      code: currentCode,
       language: currentLanguage,
     };
 
@@ -304,6 +306,7 @@ function GamePage() {
           >
             <Panel>
               <Editor
+                onCodeChange={setCurrentCode}
                 onLanguageChange={setCurrentLanguage}
                 codeMap={defaultCodeList[0]}
               />

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -188,13 +188,28 @@ function GamePage() {
     window.dispatchEvent(event);
   };
 
-  // Send notification if submission result is correct and currentUser is set.
+  // Send notification if test submission is correct and currentUser is set.
   const checkSendTestCorrectNotification = (submissionParam: SubmissionResult) => {
     if (submissionParam.numCorrect === submissionParam.numTestCases && currentUser) {
       const notificationBody: string = JSON.stringify({
         initiator: currentUser,
         time: new Date(),
         notificationType: NotificationType.TestCorrect,
+        content: 'success',
+      });
+      send(routes(roomId).subscribe_notification, {}, notificationBody);
+    }
+  };
+
+  // Send notification if solution is correct and currentUser is set.
+  const checkSendSolutionCorrectNotification = (submissionParam: SubmissionResult) => {
+    if (currentUser) {
+      const notificationBody: string = JSON.stringify({
+        initiator: currentUser,
+        time: new Date(),
+        notificationType:
+          (submissionParam.numCorrect === submissionParam.numTestCases)
+            ? NotificationType.SubmitCorrect : NotificationType.SubmitIncorrect,
         content: 'success',
       });
       send(routes(roomId).subscribe_notification, {}, notificationBody);
@@ -238,7 +253,7 @@ function GamePage() {
       .then((res) => {
         setLoading(false);
         setSubmission(res);
-        checkSendTestCorrectNotification(res);
+        checkSendSolutionCorrectNotification(res);
       })
       .catch((err) => {
         setLoading(false);

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -48,13 +48,14 @@ function GamePage() {
   const [roomId, setRoomId] = useState<string>('');
 
   const [fullPageLoading, setFullPageLoading] = useState<boolean>(true);
+  const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
   const [game, setGame] = useState<Game | null>(null);
   const [players, setPlayers] = useState<Player[]>([]);
   const [gameTimer, setGameTimer] = useState<GameTimer | null>(null);
   const [problems, setProblems] = useState<Problem[]>([]);
-  const [currentLanguage, setCurrentLanguage] = useState('java');
+  const [currentLanguage, setCurrentLanguage] = useState('python');
   const [timeUp, setTimeUp] = useState(false);
   const [allSolved, setAllSolved] = useState(false);
   const [defaultCodeList, setDefaultCodeList] = useState<DefaultCodeType[]>([]);
@@ -201,6 +202,7 @@ function GamePage() {
 
   // Callback when user runs code against custom test case
   const runSolution = (input: string) => {
+    setLoading(true);
     const request = {
       initiator: currentUser!,
       code: input,
@@ -209,10 +211,14 @@ function GamePage() {
 
     submitSolution(roomId, request)
       .then((res) => {
+        setLoading(false);
         setSubmission(res);
         checkSendTestCorrectNotification(res);
       })
-      .catch((err) => setError(err));
+      .catch((err) => {
+        setLoading(false);
+        setError(err.message);
+      });
   };
 
   const exitGame = () => {
@@ -272,6 +278,8 @@ function GamePage() {
       <CenteredContainer>
         {displayPlayerLeaderboard()}
       </CenteredContainer>
+
+      {loading ? <Loading /> : null}
 
       <SplitterContainer>
         <SplitterLayout

--- a/src/main/java/com/rocketden/main/controller/v1/GameController.java
+++ b/src/main/java/com/rocketden/main/controller/v1/GameController.java
@@ -45,6 +45,12 @@ public class GameController extends BaseRestController {
         return new ResponseEntity<>(service.sendNotification(roomId, new GameNotificationDto(request)), HttpStatus.OK);
     }
     
+    @PostMapping("/games/{roomId}/runCode")
+    public ResponseEntity<SubmissionDto> runCode(@PathVariable String roomId,
+                                                        @RequestBody SubmissionRequest request) {
+        return new ResponseEntity<>(service.runCode(roomId, request), HttpStatus.OK);
+    }
+    
     @PostMapping("/games/{roomId}/submission")
     public ResponseEntity<SubmissionDto> submitSolution(@PathVariable String roomId,
                                                         @RequestBody SubmissionRequest request) {

--- a/src/main/java/com/rocketden/main/controller/v1/GameController.java
+++ b/src/main/java/com/rocketden/main/controller/v1/GameController.java
@@ -45,7 +45,7 @@ public class GameController extends BaseRestController {
         return new ResponseEntity<>(service.sendNotification(roomId, new GameNotificationDto(request)), HttpStatus.OK);
     }
     
-    @PostMapping("/games/{roomId}/runCode")
+    @PostMapping("/games/{roomId}/run-code")
     public ResponseEntity<SubmissionDto> runCode(@PathVariable String roomId,
                                                         @RequestBody SubmissionRequest request) {
         return new ResponseEntity<>(service.runCode(roomId, request), HttpStatus.OK);

--- a/src/main/java/com/rocketden/main/dto/game/SubmissionDto.java
+++ b/src/main/java/com/rocketden/main/dto/game/SubmissionDto.java
@@ -20,6 +20,7 @@ public class SubmissionDto {
     private String code;
     private Integer numCorrect;
     private Integer numTestCases;
+    private Double runtime;
 
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @JsonSerialize(using = LocalDateTimeSerializer.class)

--- a/src/main/java/com/rocketden/main/dto/game/SubmissionDto.java
+++ b/src/main/java/com/rocketden/main/dto/game/SubmissionDto.java
@@ -10,17 +10,19 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
 @EqualsAndHashCode
 public class SubmissionDto {
-
     private CodeLanguage language;
     private String code;
+    private List<SubmissionResultDto> results;
     private Integer numCorrect;
     private Integer numTestCases;
     private Double runtime;
+    private String compilationError;
 
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @JsonSerialize(using = LocalDateTimeSerializer.class)

--- a/src/main/java/com/rocketden/main/dto/game/SubmissionMapper.java
+++ b/src/main/java/com/rocketden/main/dto/game/SubmissionMapper.java
@@ -5,11 +5,11 @@ import com.rocketden.main.game_object.SubmissionResult;
 
 import org.modelmapper.ModelMapper;
 
-public class TesterMapper {
+public class SubmissionMapper {
 
     private static final ModelMapper mapper = new ModelMapper();
 
-    protected TesterMapper() {}
+    protected SubmissionMapper() {}
 
     /**
      * This creates the SubmissionResult object from the TesterResult

--- a/src/main/java/com/rocketden/main/dto/game/SubmissionRequest.java
+++ b/src/main/java/com/rocketden/main/dto/game/SubmissionRequest.java
@@ -10,5 +10,6 @@ import lombok.Setter;
 public class SubmissionRequest {
     private CodeLanguage language;
     private String code;
+    private String input;
     private UserDto initiator;
 }

--- a/src/main/java/com/rocketden/main/dto/game/SubmissionResultDto.java
+++ b/src/main/java/com/rocketden/main/dto/game/SubmissionResultDto.java
@@ -1,0 +1,17 @@
+package com.rocketden.main.dto.game;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SubmissionResultDto {
+    // This class is mapped with the tester service's ResultDto class.
+    private String console;
+    private String userOutput;
+    private String error;
+    private String input;
+    private String correctOutput;
+    private boolean hidden;
+    private boolean correct;
+}

--- a/src/main/java/com/rocketden/main/dto/game/TesterMapper.java
+++ b/src/main/java/com/rocketden/main/dto/game/TesterMapper.java
@@ -1,0 +1,32 @@
+package com.rocketden.main.dto.game;
+
+import com.rocketden.main.dto.problem.ProblemTestCaseDto;
+import com.rocketden.main.game_object.SubmissionResult;
+
+import org.modelmapper.ModelMapper;
+
+public class TesterMapper {
+
+    private static final ModelMapper mapper = new ModelMapper();
+
+    protected TesterMapper() {}
+
+    /**
+     * This creates the SubmissionResult object from the TesterResult
+     * returned from the Tester repository, and the corresponding test case.
+     * 
+     * @param testerResult The result for a test case from the Tester repo.
+     * @param testCaseDto The relevant test case.
+     * @return The SubmissionResult constructed with the provided information.
+     */
+    public static SubmissionResult toSubmissionResult(TesterResult testerResult, ProblemTestCaseDto testCaseDto) {
+        if (testerResult == null || testCaseDto == null) {
+            return null;
+        }
+
+        SubmissionResult submissionResult = mapper.map(testerResult, SubmissionResult.class);
+        submissionResult.setHidden(testCaseDto.isHidden());
+        submissionResult.setInput(testCaseDto.getInput());
+        return submissionResult;
+    }
+}

--- a/src/main/java/com/rocketden/main/dto/game/TesterResponse.java
+++ b/src/main/java/com/rocketden/main/dto/game/TesterResponse.java
@@ -5,13 +5,11 @@ import lombok.Setter;
 
 import java.util.List;
 
-import com.rocketden.main.game_object.SubmissionResult;
-
 @Getter
 @Setter
 public class TesterResponse {
     // This class is mapped directly to the tester service's RunDto class.
-    private List<SubmissionResult> results;
+    private List<TesterResult> results;
     private Integer numCorrect;
     private Integer numTestCases;
     private Double runtime;

--- a/src/main/java/com/rocketden/main/dto/game/TesterResponse.java
+++ b/src/main/java/com/rocketden/main/dto/game/TesterResponse.java
@@ -7,20 +7,11 @@ import java.util.List;
 
 @Getter
 @Setter
-// This class is mapped directly to the tester service's RunDto class.
 public class TesterResponse {
+    // This class is mapped directly to the tester service's RunDto class.
     private List<TesterResultResponse> results;
     private Integer numCorrect;
     private Integer numTestCases;
     private Double runtime;
-
-    @Getter
-    @Setter
-    public static class TesterResultResponse {
-        private String console;
-        private String userOutput;
-        private String error;
-        private String correctOutput;
-        private boolean correct;
-    }
+    private String compilationError;
 }

--- a/src/main/java/com/rocketden/main/dto/game/TesterResponse.java
+++ b/src/main/java/com/rocketden/main/dto/game/TesterResponse.java
@@ -3,10 +3,24 @@ package com.rocketden.main.dto.game;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 // This class is mapped directly to the tester service's RunDto class.
 public class TesterResponse {
-    private Boolean status;
-    private String output;
+    private List<TesterResultResponse> results;
+    private Integer numCorrect;
+    private Integer numTestCases;
+    private Long runtime;
+
+    @Getter
+    @Setter
+    public static class TesterResultResponse {
+        private String console;
+        private String userOutput;
+        private String error;
+        private String correctOutput;
+        private boolean correct;
+    }
 }

--- a/src/main/java/com/rocketden/main/dto/game/TesterResponse.java
+++ b/src/main/java/com/rocketden/main/dto/game/TesterResponse.java
@@ -12,7 +12,7 @@ public class TesterResponse {
     private List<TesterResultResponse> results;
     private Integer numCorrect;
     private Integer numTestCases;
-    private Long runtime;
+    private Double runtime;
 
     @Getter
     @Setter

--- a/src/main/java/com/rocketden/main/dto/game/TesterResponse.java
+++ b/src/main/java/com/rocketden/main/dto/game/TesterResponse.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Setter
 public class TesterResponse {
     // This class is mapped directly to the tester service's RunDto class.
-    private List<TesterResultResponse> results;
+    private List<SubmissionResultDto> results;
     private Integer numCorrect;
     private Integer numTestCases;
     private Double runtime;

--- a/src/main/java/com/rocketden/main/dto/game/TesterResponse.java
+++ b/src/main/java/com/rocketden/main/dto/game/TesterResponse.java
@@ -5,11 +5,13 @@ import lombok.Setter;
 
 import java.util.List;
 
+import com.rocketden.main.game_object.SubmissionResult;
+
 @Getter
 @Setter
 public class TesterResponse {
     // This class is mapped directly to the tester service's RunDto class.
-    private List<SubmissionResultDto> results;
+    private List<SubmissionResult> results;
     private Integer numCorrect;
     private Integer numTestCases;
     private Double runtime;

--- a/src/main/java/com/rocketden/main/dto/game/TesterResult.java
+++ b/src/main/java/com/rocketden/main/dto/game/TesterResult.java
@@ -6,11 +6,10 @@ import lombok.Setter;
 @Getter
 @Setter
 public class TesterResult {
+    // This class is mapped directly to the tester service's ResultDto class.
     private String console;
     private String userOutput;
     private String error;
-    private String input;
     private String correctOutput;
-    private boolean hidden;
     private boolean correct;
 }

--- a/src/main/java/com/rocketden/main/dto/game/TesterResult.java
+++ b/src/main/java/com/rocketden/main/dto/game/TesterResult.java
@@ -1,0 +1,16 @@
+package com.rocketden.main.dto.game;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TesterResult {
+    private String console;
+    private String userOutput;
+    private String error;
+    private String input;
+    private String correctOutput;
+    private boolean hidden;
+    private boolean correct;
+}

--- a/src/main/java/com/rocketden/main/dto/game/TesterResultResponse.java
+++ b/src/main/java/com/rocketden/main/dto/game/TesterResultResponse.java
@@ -1,0 +1,15 @@
+package com.rocketden.main.dto.game;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TesterResultResponse {
+    // This class is mapped directly to the tester service's ResultDto class.
+    private String console;
+    private String userOutput;
+    private String error;
+    private String correctOutput;
+    private boolean correct;
+}

--- a/src/main/java/com/rocketden/main/exception/TesterError.java
+++ b/src/main/java/com/rocketden/main/exception/TesterError.java
@@ -1,0 +1,22 @@
+package com.rocketden.main.exception;
+
+import com.rocketden.main.exception.api.ApiError;
+import com.rocketden.main.exception.api.ApiErrorResponse;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class TesterError implements ApiError {
+
+    private final HttpStatus status;
+    private final ApiErrorResponse response;
+
+    public TesterError(HttpStatus status, ApiErrorResponse response) {
+        this.status = status;
+        this.response = response;
+    }
+
+    public String getMessage() {
+        return this.response.getMessage();
+    }
+}

--- a/src/main/java/com/rocketden/main/exception/TesterError.java
+++ b/src/main/java/com/rocketden/main/exception/TesterError.java
@@ -8,6 +8,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 public class TesterError implements ApiError {
 
+    /**
+     * Include default serial ID to circumvent warning.
+     */
+    private static final long serialVersionUID = 1L;
+    
     private final HttpStatus status;
     private final ApiErrorResponse response;
 

--- a/src/main/java/com/rocketden/main/exception/api/ApiErrorResponse.java
+++ b/src/main/java/com/rocketden/main/exception/api/ApiErrorResponse.java
@@ -1,12 +1,20 @@
 package com.rocketden.main.exception.api;
 
+import java.io.Serializable;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 // Response object returned to client containing message and error type (name of enum var)
 @Getter
 @EqualsAndHashCode
-public class ApiErrorResponse {
+public class ApiErrorResponse implements Serializable {
+    
+    /**
+     * Include default serial ID to circumvent warning.
+     */
+    private static final long serialVersionUID = 1L;
+
     private final String message;
     private final String type;
 

--- a/src/main/java/com/rocketden/main/game_object/Submission.java
+++ b/src/main/java/com/rocketden/main/game_object/Submission.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -12,6 +13,8 @@ import java.time.LocalDateTime;
 public class Submission {
 
     private PlayerCode playerCode;
+
+    private List<SubmissionResult> results;
 
     // The time that the submission was received.
     private LocalDateTime startTime = LocalDateTime.now();
@@ -21,4 +24,6 @@ public class Submission {
     private Integer numTestCases;
 
     private Double runtime;
+    
+    private String compilationError;
 }

--- a/src/main/java/com/rocketden/main/game_object/Submission.java
+++ b/src/main/java/com/rocketden/main/game_object/Submission.java
@@ -19,4 +19,6 @@ public class Submission {
     private Integer numCorrect;
 
     private Integer numTestCases;
+
+    private Double runtime;
 }

--- a/src/main/java/com/rocketden/main/game_object/SubmissionResult.java
+++ b/src/main/java/com/rocketden/main/game_object/SubmissionResult.java
@@ -1,15 +1,22 @@
-package com.rocketden.main.dto.game;
+package com.rocketden.main.game_object;
 
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public class TesterResultResponse {
-    // This class is mapped directly to the tester service's ResultDto class.
+public class SubmissionResult {
     private String console;
+
     private String userOutput;
+
     private String error;
+
+    private String input;
+
     private String correctOutput;
+
+    private boolean hidden;
+
     private boolean correct;
 }

--- a/src/main/java/com/rocketden/main/service/GameManagementService.java
+++ b/src/main/java/com/rocketden/main/service/GameManagementService.java
@@ -160,12 +160,7 @@ public class GameManagementService {
             throw new ApiException(GameError.INVALID_PERMISSIONS);
         }
 
-        SubmissionDto submissionDto = submitService.runCode(game, request);
-
-        // Send socket update with latest leaderboard info
-        socketService.sendSocketUpdate(GameMapper.toDto(game));
-        
-        return submissionDto;
+        return submitService.runCode(game, request);
     }
 
     // Test the submission, return the results, and send a socket update
@@ -181,7 +176,12 @@ public class GameManagementService {
             throw new ApiException(GameError.INVALID_PERMISSIONS);
         }
 
-        return submitService.submitSolution(game, request);
+        SubmissionDto submissionDto = submitService.submitSolution(game, request);
+
+        // Send socket update with latest leaderboard info
+        socketService.sendSocketUpdate(GameMapper.toDto(game));
+        
+        return submissionDto;
     }
 
     // Send a notification through a socket update.

--- a/src/main/java/com/rocketden/main/service/GameManagementService.java
+++ b/src/main/java/com/rocketden/main/service/GameManagementService.java
@@ -181,12 +181,7 @@ public class GameManagementService {
             throw new ApiException(GameError.INVALID_PERMISSIONS);
         }
 
-        SubmissionDto submissionDto = submitService.submitSolution(game, request);
-
-        // Send socket update with latest leaderboard info
-        socketService.sendSocketUpdate(GameMapper.toDto(game));
-        
-        return submissionDto;
+        return submitService.submitSolution(game, request);
     }
 
     // Send a notification through a socket update.

--- a/src/main/java/com/rocketden/main/service/GameManagementService.java
+++ b/src/main/java/com/rocketden/main/service/GameManagementService.java
@@ -148,6 +148,27 @@ public class GameManagementService {
     }
 
     // Test the submission, return the results, and send a socket update
+    public SubmissionDto runCode(String roomId, SubmissionRequest request) {
+        Game game = getGameFromRoomId(roomId);
+
+        if (request.getInitiator() == null || request.getCode() == null || request.getLanguage() == null || request.getInput() == null) {
+            throw new ApiException(GameError.EMPTY_FIELD);
+        }
+
+        String initiatorUserId = request.getInitiator().getUserId();
+        if (!game.getPlayers().containsKey(initiatorUserId)) {
+            throw new ApiException(GameError.INVALID_PERMISSIONS);
+        }
+
+        SubmissionDto submissionDto = submitService.runCode(game, request);
+
+        // Send socket update with latest leaderboard info
+        socketService.sendSocketUpdate(GameMapper.toDto(game));
+        
+        return submissionDto;
+    }
+
+    // Test the submission, return the results, and send a socket update
     public SubmissionDto submitSolution(String roomId, SubmissionRequest request) {
         Game game = getGameFromRoomId(roomId);
 

--- a/src/main/java/com/rocketden/main/service/SubmitService.java
+++ b/src/main/java/com/rocketden/main/service/SubmitService.java
@@ -9,7 +9,7 @@ import com.google.gson.Gson;
 import com.rocketden.main.dto.game.GameMapper;
 import com.rocketden.main.dto.game.SubmissionDto;
 import com.rocketden.main.dto.game.SubmissionRequest;
-import com.rocketden.main.dto.game.TesterMapper;
+import com.rocketden.main.dto.game.SubmissionMapper;
 import com.rocketden.main.dto.game.TesterRequest;
 import com.rocketden.main.dto.game.TesterResponse;
 import com.rocketden.main.dto.game.TesterResult;
@@ -182,7 +182,7 @@ public class SubmitService {
             for (TesterResult testerResult : testerResponse.getResults()) {
                 // Match the test case details with each individual result.
                 ProblemTestCaseDto testCaseDto = testCaseDtos.get(index);
-                SubmissionResult submissionResult = TesterMapper.toSubmissionResult(testerResult, testCaseDto);
+                SubmissionResult submissionResult = SubmissionMapper.toSubmissionResult(testerResult, testCaseDto);
                 results.add(submissionResult);
                 index++;
             }

--- a/src/main/java/com/rocketden/main/service/SubmitService.java
+++ b/src/main/java/com/rocketden/main/service/SubmitService.java
@@ -74,12 +74,15 @@ public class SubmitService {
         submission.setRuntime(DUMMY_RUNTIME);
 
         ProblemTestCaseDto testCaseDto = request.getProblem().getTestCases().get(0);
+        List<SubmissionResult> submissionResults = new ArrayList<>();
         SubmissionResult submissionResult = new SubmissionResult();
         submissionResult.setCorrect(true);
         submissionResult.setUserOutput(DUMMY_OUTPUT);
         submissionResult.setHidden(testCaseDto.isHidden());
         submissionResult.setInput(testCaseDto.getInput());
         submissionResult.setCorrectOutput(DUMMY_OUTPUT);
+        submissionResults.add(submissionResult);
+        submission.setResults(submissionResults);
 
         return submission;
     }

--- a/src/main/java/com/rocketden/main/service/SubmitService.java
+++ b/src/main/java/com/rocketden/main/service/SubmitService.java
@@ -1,5 +1,7 @@
 package com.rocketden.main.service;
 
+import java.io.IOException;
+
 import com.google.gson.Gson;
 import com.rocketden.main.dto.game.GameMapper;
 import com.rocketden.main.dto.game.SubmissionDto;
@@ -130,7 +132,7 @@ public class SubmitService {
     }
 
     // Sends a POST request to the tester service to judge the user submission
-    protected TesterResponse callTesterService(TesterRequest request) throws Exception {
+    protected TesterResponse callTesterService(TesterRequest request) throws IOException {
         HttpPost post = new HttpPost(getTesterUrl());
 
         StringEntity stringEntity = new StringEntity(gson.toJson(request));

--- a/src/main/java/com/rocketden/main/service/SubmitService.java
+++ b/src/main/java/com/rocketden/main/service/SubmitService.java
@@ -135,7 +135,7 @@ public class SubmitService {
             int index = 0;
             List<ProblemTestCaseDto> testCaseDtos = problem.getTestCases();
             List<SubmissionResult> results = new ArrayList<>();
-            for (SubmissionResult result : submission.getResults()) {
+            for (SubmissionResult result : testerResponse.getResults()) {
                 // Match the test case details with each individual result.
                 ProblemTestCaseDto testCaseDto = testCaseDtos.get(index);
                 result.setHidden(testCaseDto.isHidden());

--- a/src/main/java/com/rocketden/main/service/SubmitService.java
+++ b/src/main/java/com/rocketden/main/service/SubmitService.java
@@ -9,8 +9,10 @@ import com.google.gson.Gson;
 import com.rocketden.main.dto.game.GameMapper;
 import com.rocketden.main.dto.game.SubmissionDto;
 import com.rocketden.main.dto.game.SubmissionRequest;
+import com.rocketden.main.dto.game.TesterMapper;
 import com.rocketden.main.dto.game.TesterRequest;
 import com.rocketden.main.dto.game.TesterResponse;
+import com.rocketden.main.dto.game.TesterResult;
 import com.rocketden.main.dto.problem.ProblemDto;
 import com.rocketden.main.dto.problem.ProblemMapper;
 import com.rocketden.main.dto.problem.ProblemTestCaseDto;
@@ -177,12 +179,11 @@ public class SubmitService {
             int index = 0;
             List<ProblemTestCaseDto> testCaseDtos = problem.getTestCases();
             List<SubmissionResult> results = new ArrayList<>();
-            for (SubmissionResult result : testerResponse.getResults()) {
+            for (TesterResult testerResult : testerResponse.getResults()) {
                 // Match the test case details with each individual result.
                 ProblemTestCaseDto testCaseDto = testCaseDtos.get(index);
-                result.setHidden(testCaseDto.isHidden());
-                result.setInput(testCaseDto.getInput());
-                results.add(result);
+                SubmissionResult submissionResult = TesterMapper.toSubmissionResult(testerResult, testCaseDto);
+                results.add(submissionResult);
                 index++;
             }
             submission.setResults(results);

--- a/src/main/java/com/rocketden/main/service/SubmitService.java
+++ b/src/main/java/com/rocketden/main/service/SubmitService.java
@@ -43,6 +43,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class SubmitService {
 
+    protected static final Double DUMMY_RUNTIME = 5.5;
+    protected static final String DUMMY_OUTPUT = "[1, 2, 3]";
+
     private final Gson gson;
 
     // Pulls value from application.properties
@@ -68,7 +71,15 @@ public class SubmitService {
         submission.setPlayerCode(playerCode);
         submission.setNumCorrect(numTestCases);
         submission.setNumTestCases(numTestCases);
-        submission.setRuntime(5.5);
+        submission.setRuntime(DUMMY_RUNTIME);
+
+        ProblemTestCaseDto testCaseDto = request.getProblem().getTestCases().get(0);
+        SubmissionResult submissionResult = new SubmissionResult();
+        submissionResult.setCorrect(true);
+        submissionResult.setUserOutput(DUMMY_OUTPUT);
+        submissionResult.setHidden(testCaseDto.isHidden());
+        submissionResult.setInput(testCaseDto.getInput());
+        submissionResult.setCorrectOutput(DUMMY_OUTPUT);
 
         return submission;
     }

--- a/src/main/java/com/rocketden/main/service/SubmitService.java
+++ b/src/main/java/com/rocketden/main/service/SubmitService.java
@@ -43,8 +43,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class SubmitService {
 
-    protected static final Double DUMMY_RUNTIME = 5.5;
-    protected static final String DUMMY_OUTPUT = "[1, 2, 3]";
+    public static final Double DUMMY_RUNTIME = 5.5;
+    public static final String DUMMY_OUTPUT = "[1, 2, 3]";
 
     private final Gson gson;
 

--- a/src/main/java/com/rocketden/main/service/SubmitService.java
+++ b/src/main/java/com/rocketden/main/service/SubmitService.java
@@ -90,8 +90,12 @@ public class SubmitService {
         // Set the problem with the single provided test case.
         ProblemDto problemDto = ProblemMapper.toDto(game.getProblems().get(0));
         
-        // Provide a temporary output to circumvent output parsing error.
-        // TODO: Implement run code on tester repository, so output not checked.
+        /**
+         * Provide a temporary output to circumvent output parsing error.
+         *
+         * TODO: Implement run code on tester repository, so output not checked.
+         * The problem must have at least one test case to work.
+         */
         String tempOutput = problemDto.getTestCases().get(0).getOutput();
         problemDto.getTestCases().clear();
 

--- a/src/main/java/com/rocketden/main/service/SubmitService.java
+++ b/src/main/java/com/rocketden/main/service/SubmitService.java
@@ -54,6 +54,7 @@ public class SubmitService {
         submission.setPlayerCode(playerCode);
         submission.setNumCorrect(numTestCases);
         submission.setNumTestCases(numTestCases);
+        submission.setRuntime(4.5);
 
         return submission;
     }
@@ -118,11 +119,12 @@ public class SubmitService {
 
             TesterResponse testerResponse = gson.fromJson(jsonResponse, TesterResponse.class);
 
-            // TODO: logic to convert TesterResponse into Submission object
             Submission submission = new Submission();
-            submission.setNumCorrect(request.getProblem().getTestCases().size());
-            submission.setNumTestCases(request.getProblem().getTestCases().size());
+            submission.setNumCorrect(testerResponse.getNumCorrect());
+            submission.setNumTestCases(testerResponse.getNumTestCases());
+            submission.setRuntime(testerResponse.getRuntime());
             submission.setPlayerCode(new PlayerCode(request.getCode(), request.getLanguage()));
+
 
             return submission;
         } catch (Exception e) {

--- a/src/main/java/com/rocketden/main/service/SubmitService.java
+++ b/src/main/java/com/rocketden/main/service/SubmitService.java
@@ -9,19 +9,13 @@ import com.rocketden.main.dto.game.TesterResponse;
 import com.rocketden.main.dto.problem.ProblemMapper;
 import com.rocketden.main.exception.GameError;
 import com.rocketden.main.exception.TesterError;
-import com.rocketden.main.exception.api.ApiError;
 import com.rocketden.main.exception.api.ApiErrorResponse;
 import com.rocketden.main.exception.api.ApiException;
-import com.rocketden.main.game_object.CodeLanguage;
 import com.rocketden.main.game_object.Game;
 
 import com.rocketden.main.game_object.Player;
 import com.rocketden.main.game_object.PlayerCode;
 import com.rocketden.main.game_object.Submission;
-import com.rocketden.main.model.problem.Problem;
-import com.rocketden.main.model.problem.ProblemIOType;
-import com.rocketden.main.model.problem.ProblemInput;
-import com.rocketden.main.model.problem.ProblemTestCase;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
@@ -172,58 +166,5 @@ public class SubmitService {
     // This method should only be called for testing purposes
     protected void setDebugModeForTesting(boolean debugMode) {
         this.debugMode = debugMode;
-    }
-
-    // TODO: Manual testing purposes only - delete later
-    public static void main(String[] args) {
-        Problem problem = new Problem();
-        ProblemInput input = new ProblemInput();
-        input.setName("num");
-        input.setType(ProblemIOType.INTEGER);
-        problem.addProblemInput(input);
-        problem.setOutputType(ProblemIOType.INTEGER);
-
-        ProblemTestCase testCase = new ProblemTestCase();
-        testCase.setInput("5");
-        testCase.setOutput("10");
-        problem.addTestCase(testCase);
-
-        TesterRequest testerRequest = new TesterRequest();
-        testerRequest.setCode("class Solution:\n\tdef solve(num):\n\t\t:return num * 2");
-        testerRequest.setLanguage(CodeLanguage.PYTHON);
-        testerRequest.setProblem(ProblemMapper.toDto(problem));
-
-        try {
-            HttpPost post = new HttpPost("https://rocketden-tester.herokuapp.com/api/v1/runner");
-
-            StringEntity stringEntity = new StringEntity(new Gson().toJson(testerRequest));
-            post.setEntity(stringEntity);
-            post.setHeader("Content-type", "application/json");
-
-            HttpResponse response = HttpClientBuilder.create().build().execute(post);
-            String jsonResponse = EntityUtils.toString(response.getEntity());
-
-            // Throw tester error if the tester returns an error response
-            int status = response.getStatusLine().getStatusCode();
-            if (status >= 400) {
-                ApiErrorResponse error = new Gson().fromJson(jsonResponse, ApiErrorResponse.class);
-                throw new ApiException(new TesterError(HttpStatus.valueOf(status), error));
-            }
-
-            TesterResponse testerResponse = new Gson().fromJson(jsonResponse, TesterResponse.class);
-
-            Submission submission = new Submission();
-            submission.setNumCorrect(testerResponse.getNumCorrect());
-            submission.setNumTestCases(testerResponse.getNumTestCases());
-            submission.setRuntime(testerResponse.getRuntime());
-
-            System.out.println(submission);
-        } catch (ApiException e) {
-            // If custom ApiException is thrown, pass that as the response
-            throw e;
-        } catch (Exception e) {
-            // Throw generic 500 error
-            throw new ApiException(GameError.TESTER_ERROR);
-        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,5 +15,5 @@ spring.datasource.hikari.maxLifetime=30000
 spring.datasource.hikari.maximumPoolSize=2
 
 # Whether to return dummy submission when tester service is unavailable
-tester.debugMode=true
-tester.url=https://rocketden-tester.herokuapp.com/api/v1/runner
+tester.debugMode=false
+tester.url=http://35.238.172.126:8080/api/v1/runner

--- a/src/test/java/com/rocketden/main/mapper/GameMapperTests.java
+++ b/src/test/java/com/rocketden/main/mapper/GameMapperTests.java
@@ -146,12 +146,14 @@ public class GameMapperTests {
         submission.setPlayerCode(playerCode);
         submission.setNumTestCases(TEST_CASES);
         submission.setNumCorrect(TEST_CASES);
+        submission.setRuntime(5.5);
 
         SubmissionDto submissionDto = GameMapper.submissionToDto(submission);
         assertEquals(submission.getPlayerCode().getCode(), submissionDto.getCode());
         assertEquals(submission.getPlayerCode().getLanguage(), submissionDto.getLanguage());
         assertEquals(submission.getNumCorrect(), submissionDto.getNumCorrect());
         assertEquals(submission.getStartTime(), submissionDto.getStartTime());
+        assertEquals(submission.getRuntime(), submissionDto.getRuntime());
     }
 
     @Test

--- a/src/test/java/com/rocketden/main/mapper/SubmissionMapperTests.java
+++ b/src/test/java/com/rocketden/main/mapper/SubmissionMapperTests.java
@@ -1,0 +1,41 @@
+package com.rocketden.main.mapper;
+
+import com.rocketden.main.dto.game.SubmissionMapper;
+import com.rocketden.main.dto.game.TesterResult;
+import com.rocketden.main.dto.problem.ProblemTestCaseDto;
+import com.rocketden.main.game_object.SubmissionResult;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class SubmissionMapperTests {
+
+    private static final String INPUT = "[1, 8, 2]";
+    private static final String OUTPUT = "[1, 2, 8]";
+
+    @Test
+    public void toSubmissionResult() {
+        TesterResult testerResult = new TesterResult();
+        testerResult.setConsole(null);
+        testerResult.setUserOutput(OUTPUT);
+        testerResult.setError(null);
+        testerResult.setCorrectOutput(OUTPUT);
+        testerResult.setCorrect(true);
+
+        ProblemTestCaseDto testCaseDto = new ProblemTestCaseDto();
+        testCaseDto.setHidden(false);
+        testCaseDto.setInput(INPUT);
+
+        SubmissionResult submissionResult = SubmissionMapper.toSubmissionResult(testerResult, testCaseDto);
+        assertEquals(testerResult.getConsole(), submissionResult.getConsole());
+        assertEquals(testerResult.getUserOutput(), submissionResult.getUserOutput());
+        assertEquals(testerResult.getError(), submissionResult.getError());
+        assertEquals(testerResult.getCorrectOutput(), submissionResult.getCorrectOutput());
+        assertEquals(testerResult.isCorrect(), submissionResult.isCorrect());
+        assertEquals(testCaseDto.isHidden(), submissionResult.isHidden());
+        assertEquals(testCaseDto.getInput(), submissionResult.getInput());
+    }
+}

--- a/src/test/java/com/rocketden/main/service/GameManagementServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/GameManagementServiceTests.java
@@ -43,7 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDateTime;

--- a/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
@@ -114,18 +114,34 @@ public class SubmitServiceTests {
         assertFalse(game.getAllSolved());
     }
 
-    // This is a very weak test - it simply resorts to ensuring a submission is returned in debug mode
-    // TODO: test dummy response, success response, 400 tester error response, 500 generic error response
     @Test
-    public void callTesterServiceSuccess() {
+    public void callTesterServiceReturnsDummyResponse() {
         TesterRequest request = new TesterRequest();
         request.setCode(CODE);
         request.setLanguage(LANGUAGE);
         request.setProblem(new ProblemDto());
 
-        Submission response = submitService.callTesterService(request);
+        Submission response = submitService.getSubmission(request);
 
         assertNotNull(response);
+    }
+
+    @Test
+    public void callTesterServiceSuccessfulApiCall() {
+        submitService.setDebugModeForTesting(false);
+
+    }
+
+    @Test
+    public void callTesterServiceTesterThrowsError() {
+        submitService.setDebugModeForTesting(false);
+
+    }
+
+    @Test
+    public void callTesterServiceInternalError() {
+        submitService.setDebugModeForTesting(false);
+
     }
 
     @Test

--- a/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
@@ -22,7 +22,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mockito;
 import org.mockito.Spy;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import org.springframework.http.HttpStatus;
 
 import java.util.ArrayList;
@@ -214,7 +216,12 @@ public class SubmitServiceTests {
         testerResponse.setNumTestCases(1);
         testerResponse.setRuntime(5.5);
 
-        Mockito.doThrow(new Exception()).when(submitService).callTesterService(request);
+        // Use doAnswer to avoid checked exception mock error.
+        Mockito.doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) throws Exception {
+                throw new Exception();
+            }})
+          .when(submitService).callTesterService(request);
 
         ApiException exception = assertThrows(ApiException.class, () -> submitService.getSubmission(request));
 

--- a/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
@@ -1,6 +1,7 @@
 package com.rocketden.main.service;
 
 import com.rocketden.main.dto.game.GameMapper;
+import com.rocketden.main.dto.game.SubmissionDto;
 import com.rocketden.main.dto.game.SubmissionRequest;
 import com.rocketden.main.dto.game.TesterRequest;
 import com.rocketden.main.dto.game.TesterResponse;
@@ -17,6 +18,8 @@ import com.rocketden.main.game_object.Submission;
 import com.rocketden.main.model.Room;
 import com.rocketden.main.model.User;
 import com.rocketden.main.model.problem.Problem;
+import com.rocketden.main.model.problem.ProblemTestCase;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -42,6 +45,10 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 public class SubmitServiceTests {
 
+    private static final String NAME = "Sort an Array";
+    private static final String INPUT = "[1, 8, 2]";
+    private static final String OUTPUT = "[1, 2, 8]";
+
     private static final String NICKNAME = "rocket";
     private static final String USER_ID = "098765";
     private static final String NICKNAME_2 = "rocketrocket";
@@ -53,6 +60,43 @@ public class SubmitServiceTests {
     @Spy
     @InjectMocks
     private SubmitService submitService;
+
+    @Test
+    public void runCodeSuccess() {
+        Room room = new Room();
+        room.setRoomId(ROOM_ID);
+        User user = new User();
+        user.setNickname(NICKNAME);
+        user.setUserId(USER_ID);
+        room.addUser(user);
+
+        Game game = GameMapper.fromRoom(room);
+
+        List<Problem> problems = new ArrayList<>();
+        Problem problem = new Problem();
+        problem.setName(NAME);
+
+        ProblemTestCase testCase = new ProblemTestCase();
+        testCase.setInput(INPUT);
+        testCase.setOutput(OUTPUT);
+        problem.addTestCase(testCase);
+        problems.add(problem);
+        game.setProblems(problems);
+
+        SubmissionRequest request = new SubmissionRequest();
+        request.setLanguage(LANGUAGE);
+        request.setCode(CODE);
+        request.setInput(INPUT);
+        request.setInitiator(UserMapper.toDto(user));
+
+        SubmissionDto submissionDto = submitService.runCode(game, request);
+
+        assertEquals(CODE, submissionDto.getCode());
+        assertEquals(LANGUAGE, submissionDto.getLanguage());
+        assertEquals(submissionDto.getNumCorrect(), submissionDto.getNumTestCases());
+        assertNotNull(submissionDto.getRuntime());
+        assertFalse(game.getAllSolved());
+    }
 
     @Test
     public void submitSolutionSuccess() {

--- a/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
@@ -73,6 +73,7 @@ public class SubmitServiceTests {
         assertEquals(CODE, submission.getPlayerCode().getCode());
         assertEquals(LANGUAGE, submission.getPlayerCode().getLanguage());
         assertEquals(submission.getNumCorrect(), submission.getNumTestCases());
+        assertNotNull(submission.getRuntime());
         assertTrue(game.getAllSolved());
     }
 
@@ -109,6 +110,7 @@ public class SubmitServiceTests {
         assertEquals(CODE, submission.getPlayerCode().getCode());
         assertEquals(LANGUAGE, submission.getPlayerCode().getLanguage());
         assertEquals(submission.getNumCorrect(), submission.getNumTestCases());
+        assertNotNull(submission.getRuntime());
         assertFalse(game.getAllSolved());
     }
 

--- a/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
@@ -16,6 +16,7 @@ import com.rocketden.main.exception.api.ApiException;
 import com.rocketden.main.game_object.CodeLanguage;
 import com.rocketden.main.game_object.Game;
 import com.rocketden.main.game_object.Submission;
+import com.rocketden.main.game_object.SubmissionResult;
 import com.rocketden.main.model.Room;
 import com.rocketden.main.model.User;
 import com.rocketden.main.model.problem.Problem;
@@ -125,7 +126,14 @@ public class SubmitServiceTests {
         Game game = GameMapper.fromRoom(room);
 
         List<Problem> problems = new ArrayList<>();
-        problems.add(new Problem());
+        Problem problem = new Problem();
+        problem.setName(NAME);
+
+        ProblemTestCase testCase = new ProblemTestCase();
+        testCase.setInput(INPUT);
+        testCase.setOutput(OUTPUT);
+        problem.addTestCase(testCase);
+        problems.add(problem);
         game.setProblems(problems);
 
         SubmissionRequest request = new SubmissionRequest();
@@ -139,11 +147,22 @@ public class SubmitServiceTests {
         assertEquals(1, submissions.size());
 
         Submission submission = submissions.get(0);
-
         assertEquals(CODE, submission.getPlayerCode().getCode());
         assertEquals(LANGUAGE, submission.getPlayerCode().getLanguage());
         assertEquals(submission.getNumCorrect(), submission.getNumTestCases());
-        assertNotNull(submission.getRuntime());
+        assertNull(submission.getCompilationError());
+        assertEquals(RUNTIME, submission.getRuntime());
+        assertTrue(LocalDateTime.now().isAfter(submission.getStartTime())
+            || LocalDateTime.now().minusSeconds((long) 1).isBefore(submission.getStartTime()));
+
+        SubmissionResult submissionResult = submission.getResults().get(0);
+        assertEquals(OUTPUT, submissionResult.getUserOutput());
+        assertNull(submissionResult.getError());
+        assertEquals(INPUT, submissionResult.getInput());
+        assertEquals(OUTPUT, submissionResult.getCorrectOutput());
+        assertFalse(submissionResult.isHidden());
+        assertTrue(submissionResult.isCorrect());
+        
         assertTrue(game.getAllSolved());
     }
 
@@ -162,7 +181,14 @@ public class SubmitServiceTests {
 
         Game game = GameMapper.fromRoom(room);
         List<Problem> problems = new ArrayList<>();
-        problems.add(new Problem());
+        Problem problem = new Problem();
+        problem.setName(NAME);
+
+        ProblemTestCase testCase = new ProblemTestCase();
+        testCase.setInput(INPUT);
+        testCase.setOutput(OUTPUT);
+        problem.addTestCase(testCase);
+        problems.add(problem);
         game.setProblems(problems);
 
         SubmissionRequest request = new SubmissionRequest();
@@ -176,11 +202,22 @@ public class SubmitServiceTests {
         assertEquals(1, submissions.size());
 
         Submission submission = submissions.get(0);
-
         assertEquals(CODE, submission.getPlayerCode().getCode());
         assertEquals(LANGUAGE, submission.getPlayerCode().getLanguage());
         assertEquals(submission.getNumCorrect(), submission.getNumTestCases());
-        assertNotNull(submission.getRuntime());
+        assertNull(submission.getCompilationError());
+        assertEquals(RUNTIME, submission.getRuntime());
+        assertTrue(LocalDateTime.now().isAfter(submission.getStartTime())
+            || LocalDateTime.now().minusSeconds((long) 1).isBefore(submission.getStartTime()));
+
+        SubmissionResult submissionResult = submission.getResults().get(0);
+        assertEquals(OUTPUT, submissionResult.getUserOutput());
+        assertNull(submissionResult.getError());
+        assertEquals(INPUT, submissionResult.getInput());
+        assertEquals(OUTPUT, submissionResult.getCorrectOutput());
+        assertFalse(submissionResult.isHidden());
+        assertTrue(submissionResult.isCorrect());
+        
         assertFalse(game.getAllSolved());
     }
 

--- a/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
@@ -2,6 +2,7 @@ package com.rocketden.main.service;
 
 import com.rocketden.main.dto.game.GameMapper;
 import com.rocketden.main.dto.game.SubmissionDto;
+import com.rocketden.main.dto.game.SubmissionResultDto;
 import com.rocketden.main.dto.game.SubmissionRequest;
 import com.rocketden.main.dto.game.TesterRequest;
 import com.rocketden.main.dto.game.TesterResponse;
@@ -30,12 +31,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 import org.springframework.http.HttpStatus;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -46,8 +49,9 @@ import static org.mockito.Mockito.verify;
 public class SubmitServiceTests {
 
     private static final String NAME = "Sort an Array";
-    private static final String INPUT = "[1, 8, 2]";
-    private static final String OUTPUT = "[1, 2, 8]";
+    private static final String INPUT = "[1, 3, 2]";
+    private static final String OUTPUT = SubmitService.DUMMY_OUTPUT;
+    private static final Double RUNTIME = SubmitService.DUMMY_RUNTIME;
 
     private static final String NICKNAME = "rocket";
     private static final String USER_ID = "098765";
@@ -90,11 +94,22 @@ public class SubmitServiceTests {
         request.setInitiator(UserMapper.toDto(user));
 
         SubmissionDto submissionDto = submitService.runCode(game, request);
-
         assertEquals(CODE, submissionDto.getCode());
         assertEquals(LANGUAGE, submissionDto.getLanguage());
         assertEquals(submissionDto.getNumCorrect(), submissionDto.getNumTestCases());
-        assertNotNull(submissionDto.getRuntime());
+        assertNull(submissionDto.getCompilationError());
+        assertEquals(RUNTIME, submissionDto.getRuntime());
+        assertTrue(LocalDateTime.now().isAfter(submissionDto.getStartTime())
+            || LocalDateTime.now().minusSeconds((long) 1).isBefore(submissionDto.getStartTime()));
+
+        SubmissionResultDto resultDto = submissionDto.getResults().get(0);
+        assertEquals(OUTPUT, resultDto.getUserOutput());
+        assertNull(resultDto.getError());
+        assertEquals(INPUT, resultDto.getInput());
+        assertEquals(OUTPUT, resultDto.getCorrectOutput());
+        assertFalse(resultDto.isHidden());
+        assertTrue(resultDto.isCorrect());
+        
         assertFalse(game.getAllSolved());
     }
 

--- a/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
@@ -159,6 +159,7 @@ public class SubmitServiceTests {
         testerResponse.setNumCorrect(1);
         testerResponse.setNumTestCases(1);
         testerResponse.setRuntime(5.5);
+        testerResponse.setResults(new ArrayList<>());
 
         Mockito.doReturn(testerResponse).when(submitService).callTesterService(request);
         Submission response = submitService.getSubmission(request);

--- a/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
@@ -115,6 +115,7 @@ public class SubmitServiceTests {
     }
 
     // This is a very weak test - it simply resorts to ensuring a submission is returned in debug mode
+    // TODO: test dummy response, success response, 400 tester error response, 500 generic error response
     @Test
     public void callTesterServiceSuccess() {
         TesterRequest request = new TesterRequest();

--- a/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/SubmitServiceTests.java
@@ -3,9 +3,13 @@ package com.rocketden.main.service;
 import com.rocketden.main.dto.game.GameMapper;
 import com.rocketden.main.dto.game.SubmissionRequest;
 import com.rocketden.main.dto.game.TesterRequest;
+import com.rocketden.main.dto.game.TesterResponse;
+import com.rocketden.main.dto.problem.ProblemTestCaseDto;
 import com.rocketden.main.dto.user.UserMapper;
 import com.rocketden.main.dto.problem.ProblemDto;
 import com.rocketden.main.exception.GameError;
+import com.rocketden.main.exception.TesterError;
+import com.rocketden.main.exception.api.ApiErrorResponse;
 import com.rocketden.main.exception.api.ApiException;
 import com.rocketden.main.game_object.CodeLanguage;
 import com.rocketden.main.game_object.Game;
@@ -16,10 +20,13 @@ import com.rocketden.main.model.problem.Problem;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -27,6 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class SubmitServiceTests {
@@ -115,44 +124,113 @@ public class SubmitServiceTests {
     }
 
     @Test
-    public void callTesterServiceReturnsDummyResponse() {
+    public void callTesterServiceReturnsDummyResponse() throws Exception {
+        ProblemTestCaseDto testCaseDto = new ProblemTestCaseDto();
+        ProblemDto problemDto = new ProblemDto();
+        problemDto.setTestCases(Collections.singletonList(testCaseDto));
+
         TesterRequest request = new TesterRequest();
         request.setCode(CODE);
         request.setLanguage(LANGUAGE);
-        request.setProblem(new ProblemDto());
+        request.setProblem(problemDto);
 
         Submission response = submitService.getSubmission(request);
 
         assertNotNull(response);
+        verify(submitService, never()).callTesterService(Mockito.any());
     }
 
     @Test
-    public void callTesterServiceSuccessfulApiCall() {
+    public void callTesterServiceSuccessfulApiCall() throws Exception {
         submitService.setDebugModeForTesting(false);
 
+        ProblemTestCaseDto testCaseDto = new ProblemTestCaseDto();
+        ProblemDto problemDto = new ProblemDto();
+        problemDto.setTestCases(Collections.singletonList(testCaseDto));
+
+        TesterRequest request = new TesterRequest();
+        request.setCode(CODE);
+        request.setLanguage(LANGUAGE);
+        request.setProblem(problemDto);
+
+        TesterResponse testerResponse = new TesterResponse();
+        testerResponse.setNumCorrect(1);
+        testerResponse.setNumTestCases(1);
+        testerResponse.setRuntime(5.5);
+
+        Mockito.doReturn(testerResponse).when(submitService).callTesterService(request);
+        Submission response = submitService.getSubmission(request);
+
+        assertEquals(testerResponse.getNumCorrect(), response.getNumCorrect());
+        assertEquals(testerResponse.getNumTestCases(), response.getNumTestCases());
+        assertEquals(testerResponse.getRuntime(), response.getRuntime());
+        assertEquals(request.getCode(), response.getPlayerCode().getCode());
+        assertEquals(request.getLanguage(), response.getPlayerCode().getLanguage());
+        assertNotNull(response.getStartTime());
     }
 
     @Test
-    public void callTesterServiceTesterThrowsError() {
+    public void callTesterServiceTesterThrowsError() throws Exception {
         submitService.setDebugModeForTesting(false);
 
+        ProblemTestCaseDto testCaseDto = new ProblemTestCaseDto();
+        ProblemDto problemDto = new ProblemDto();
+        problemDto.setTestCases(Collections.singletonList(testCaseDto));
+
+        TesterRequest request = new TesterRequest();
+        request.setCode(CODE);
+        request.setLanguage(LANGUAGE);
+        request.setProblem(problemDto);
+
+        TesterResponse testerResponse = new TesterResponse();
+        testerResponse.setNumCorrect(1);
+        testerResponse.setNumTestCases(1);
+        testerResponse.setRuntime(5.5);
+
+        TesterError ERROR = new TesterError(HttpStatus.BAD_REQUEST, new ApiErrorResponse("Bad input", "INVALID_INPUT"));
+
+        Mockito.doThrow(new ApiException(ERROR)).when(submitService).callTesterService(request);
+
+        ApiException exception = assertThrows(ApiException.class, () -> submitService.getSubmission(request));
+
+        assertEquals(ERROR, exception.getError());
     }
 
     @Test
-    public void callTesterServiceInternalError() {
+    public void callTesterServiceInternalError() throws Exception {
         submitService.setDebugModeForTesting(false);
 
+        ProblemTestCaseDto testCaseDto = new ProblemTestCaseDto();
+        ProblemDto problemDto = new ProblemDto();
+        problemDto.setTestCases(Collections.singletonList(testCaseDto));
+
+        TesterRequest request = new TesterRequest();
+        request.setCode(CODE);
+        request.setLanguage(LANGUAGE);
+        request.setProblem(problemDto);
+
+        TesterResponse testerResponse = new TesterResponse();
+        testerResponse.setNumCorrect(1);
+        testerResponse.setNumTestCases(1);
+        testerResponse.setRuntime(5.5);
+
+        Mockito.doThrow(new Exception()).when(submitService).callTesterService(request);
+
+        ApiException exception = assertThrows(ApiException.class, () -> submitService.getSubmission(request));
+
+        assertEquals(GameError.TESTER_ERROR, exception.getError());
     }
 
     @Test
-    public void callTesterServiceFailsNoDebug() {
+    public void callTesterServiceErrorWithPostRequest() {
         submitService.setDebugModeForTesting(false);
 
         TesterRequest request = new TesterRequest();
         request.setCode("temp");
 
-        ApiException exception = assertThrows(ApiException.class, () -> submitService.callTesterService(request));
+        assertThrows(Exception.class, () -> submitService.callTesterService(request));
 
+        ApiException exception = assertThrows(ApiException.class, () -> submitService.getSubmission(request));
         assertEquals(GameError.TESTER_ERROR, exception.getError());
     }
 }


### PR DESCRIPTION
### List of Changes:

* Update TesterReponse class to match the RunDto on the tester repo 
* Create new TesterError class to map errors from the tester repo
* Return different error for tester triggered error and internal POST call error
* Add additional test cases for newly refactored SubmitService setup
* Change default code to use spaces to prevent Python tab-space mix error on tester
* Display output from submission on the frontend, in the "output" container.
* Create separate calls in the backend to differentiate between "run code" and "submit".

### Notes:

* The tester API call should have slightly better test coverage now, although not perfect 
* The TesterError class is not an enum, so we can dynamically create them and don't have to copy all the errors from the tester repo over into main
* Right now, the output displayed in a small box, and is definitely not user-friendly. I'm assuming this is a low priority right now though, as we are just trying to get the MVP out.
* If the problem does not have at least one test case, it cannot do the "run code" operation as the output passed through there is the same as the first test case, to ensure that it passes all parsing checks in the tester repository.
* If the user does not have a "return" statement (at least in Java code), this is seen as misformatted output and not as a compilation error. I'm not certain why this is, but I figured troubleshooting this issue could be left to another PR - see [the #15 tester issue](https://github.com/rocketden/tester/issues/15).

### Screencast and Images:

[Screencast of the Run Code and Submit Functionality](https://www.loom.com/share/eb10a65b09174bd69477bb5ae7c47dfa)

**Images of the Correct Submission with Hidden and Open Test Cases**
_Three submissions are shown below, as I scrolled down the "output" container (it could not be enlarged any more)._

<img width="1250" alt="Image of the Correct Submission" src="https://user-images.githubusercontent.com/7987279/108637075-df1d5280-743d-11eb-874e-892c02319781.png">
<img width="1247" alt="Image of the Correct Submission" src="https://user-images.githubusercontent.com/7987279/108637077-e2184300-743d-11eb-8023-d0a98498ff69.png">
<img width="1250" alt="Image of the Correct Submission" src="https://user-images.githubusercontent.com/7987279/108637079-e47a9d00-743d-11eb-8ae1-a344e82dc39e.png">

**Image of the Test Case Result**
<img width="1249" alt="Image of the Test Case Result" src="https://user-images.githubusercontent.com/7987279/108637400-4d164980-743f-11eb-98d9-696ac53ea6ab.png">
