### PR TITLE
Create the Contact Us page.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@types/stompjs": "^2.3.4",
     "@types/styled-components": "^5.1.2",
     "axios": "^0.21.1",
+    "copy-to-clipboard": "^3.3.1",
     "monaco-editor": "^0.21.2",
     "monaco-editor-webpack-plugin": "^2.0.0",
     "react": "^16.13.1",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/frontend/src/components/config/App.tsx
+++ b/frontend/src/components/config/App.tsx
@@ -14,6 +14,7 @@ import AllProblemsPage from '../../views/AllProblemsPage';
 import ProblemPage from '../../views/ProblemPage';
 import CreateProblemPage from '../../views/CreateProblemPage';
 import CircleBackgroundLayout from '../layout/CircleBackground';
+import ContactUsPage from '../../views/ContactUs';
 
 function App() {
   return (
@@ -27,6 +28,7 @@ function App() {
       <CustomRoute path="/problems/all" component={AllProblemsPage} layout={MainLayout} exact />
       <CustomRoute path="/problem/create" component={CreateProblemPage} layout={MainLayout} exact />
       <CustomRoute path="/problem/:id" component={ProblemPage} layout={MainLayout} exact />
+      <CustomRoute path="/contact-us" component={ContactUsPage} layout={MainLayout} exact />
       <CustomRoute path="*" component={NotFound} layout={MainLayout} />
     </Switch>
   );

--- a/frontend/src/components/config/Theme.tsx
+++ b/frontend/src/components/config/Theme.tsx
@@ -16,6 +16,7 @@ export const ThemeConfig: any = {
     gray: 'gray',
     lightGray: 'lightgray',
     white: 'white',
+    blueLink: '#0000EE',
     gradients: {
       green: 'linear-gradient(207.68deg, #14D633 10.68%, #DAFFB5 91.96%)',
       red: 'linear-gradient(207.68deg, #DD145D 10.68%, #FFB7B7 91.96%)',

--- a/frontend/src/components/core/Link.tsx
+++ b/frontend/src/components/core/Link.tsx
@@ -28,3 +28,7 @@ export const TextLink = styled(Link)`
   color: ${({ theme }) => theme.colors.gray};
   text-decoration: none;
 `;
+
+export const InlineExternalLink = styled.a`
+  color: ${({ theme }) => theme.colors.blueLink};
+`;

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -37,6 +37,18 @@ export const LandingHeaderText = styled.h1`
   font-weight: 400;
 `;
 
+export const ContactHeaderTitle = styled.h1`
+  font-size: ${({ theme }) => theme.fontSize.xLarge};
+  color: ${({ theme }) => theme.colors.darkText};
+  font-weight: 700;
+`;
+
+export const ContactHeaderText = styled.h1`
+  text-align: left;
+  font-size: ${({ theme }) => theme.fontSize.xMediumLarge};
+  font-weight: 400;
+`;
+
 export const UserNicknameText = styled(LargeText)`
   margin: 0;
 `;

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -49,6 +49,14 @@ export const ContactHeaderText = styled.h1`
   font-weight: 400;
 `;
 
+export const InlineHeaderCopyText = styled(ContactHeaderText)`
+  display: inline-block;
+  padding: 0.2rem 1rem;
+  border-radius: 1rem;
+  background: ${({ theme }) => theme.colors.text};
+  color: ${({ theme }) => theme.colors.white};
+`;
+
 export const UserNicknameText = styled(LargeText)`
   margin: 0;
 `;

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -49,14 +49,6 @@ export const ContactHeaderText = styled.h1`
   font-weight: 400;
 `;
 
-export const InlineHeaderCopyText = styled(ContactHeaderText)`
-  display: inline-block;
-  padding: 0.2rem 1rem;
-  border-radius: 1rem;
-  background: ${({ theme }) => theme.colors.text};
-  color: ${({ theme }) => theme.colors.white};
-`;
-
 export const UserNicknameText = styled(LargeText)`
   margin: 0;
 `;

--- a/frontend/src/components/navigation/Header.tsx
+++ b/frontend/src/components/navigation/Header.tsx
@@ -33,7 +33,7 @@ function Header() {
           />
           CodeJoust
         </LeftHeader>
-        <RightHeader to="contact-us">
+        <RightHeader to="/contact-us">
           Contact Us
         </RightHeader>
       </nav>

--- a/frontend/src/components/special/CopyIndicator.tsx
+++ b/frontend/src/components/special/CopyIndicator.tsx
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+import { DefaultButton } from '../core/Button';
+import { ContactHeaderText } from '../core/Text';
+
+type CopyIndicator = {
+  copied: boolean,
+}
+
+export const CopyIndicatorContainer = styled.div.attrs((props: CopyIndicator) => ({
+  style: {
+    transform: (!props.copied) ? 'translateY(-60px)' : null,
+  },
+}))<CopyIndicator>`
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transition: transform 0.25s;
+`;
+
+export const CopyIndicator = styled(DefaultButton)`
+  position: relative;
+  left: -50%;
+  margin: 0 auto;
+  padding: 0.25rem 1rem;
+  color: ${({ theme }) => theme.colors.white};
+  background: ${({ theme }) => theme.colors.gradients.green};
+`;
+
+export const InlineCopyText = styled(ContactHeaderText)`
+  display: inline-block;
+  margin: 0;
+  cursor: pointer;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.text};
+`;
+
+export const InlineCopyIcon = styled.i.attrs(() => ({
+  className: 'material-icons',
+}))`
+  margin-left: 5px;
+`;

--- a/frontend/src/views/ContactUs.tsx
+++ b/frontend/src/views/ContactUs.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import copy from 'copy-to-clipboard';
 import { LandingPageContainer } from '../components/core/Container';
 import { InlineExternalLink } from '../components/core/Link';
 import { ContactHeaderTitle, ContactHeaderText } from '../components/core/Text';
@@ -41,7 +42,7 @@ function ContactUsPage() {
           {' '}
           <InlineCopyText
             onClick={() => {
-              navigator.clipboard.writeText('support@codejoust.co');
+              copy('support@codejoust.co');
               setCopiedEmail(true);
             }}
           >

--- a/frontend/src/views/ContactUs.tsx
+++ b/frontend/src/views/ContactUs.tsx
@@ -1,53 +1,22 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
-import { DefaultButton } from '../components/core/Button';
 import { LandingPageContainer } from '../components/core/Container';
 import { InlineExternalLink } from '../components/core/Link';
 import { ContactHeaderTitle, ContactHeaderText } from '../components/core/Text';
-
-type CopyIndicator = {
-  copiedEmail: boolean,
-}
-
-const CopyIndicatorContainer = styled.div.attrs((props: CopyIndicator) => ({
-  style: {
-    transform: (!props.copiedEmail) ? 'translateY(-60px)' : null,
-  },
-}))<CopyIndicator>`
-  position: absolute;
-  top: 20px;
-  left: 50%;
-  transition: transform 0.25s;
-`;
-
-const CopyIndicator = styled(DefaultButton)`
-  position: relative;
-  left: -50%;
-  margin: 0 auto;
-  padding: 0.25rem 1rem;
-  color: ${({ theme }) => theme.colors.white};
-  background: ${({ theme }) => theme.colors.gradients.green};
-`;
+import {
+  CopyIndicator,
+  CopyIndicatorContainer,
+  InlineCopyIcon,
+  InlineCopyText,
+} from '../components/special/CopyIndicator';
 
 function ContactUsPage() {
-  const InlineEmailCopyText = styled(ContactHeaderText)`
-    display: inline-block;
-    margin: 0;
-    cursor: pointer;
-    border-bottom: 1px solid ${({ theme }) => theme.colors.text};
-  `;
-
-  const CopyIcon = styled.i`
-    margin-left: 5px;
-  `;
-
   const [copiedEmail, setCopiedEmail] = useState<boolean>(false);
 
   return (
     <>
-      <CopyIndicatorContainer copiedEmail={copiedEmail}>
+      <CopyIndicatorContainer copied={copiedEmail}>
         <CopyIndicator onClick={() => setCopiedEmail(false)}>
-          Email copied to clipboard!&nbsp;&nbsp;✕
+          Email copied!&nbsp;&nbsp;✕
         </CopyIndicator>
       </CopyIndicatorContainer>
       <LandingPageContainer>
@@ -70,15 +39,15 @@ function ContactUsPage() {
         <ContactHeaderText>
           You can contact us at
           {' '}
-          <InlineEmailCopyText
+          <InlineCopyText
             onClick={() => {
               navigator.clipboard.writeText('support@codejoust.co');
               setCopiedEmail(true);
             }}
           >
             support@codejoust.co
-            <CopyIcon className="material-icons">content_copy</CopyIcon>
-          </InlineEmailCopyText>
+            <InlineCopyIcon>content_copy</InlineCopyIcon>
+          </InlineCopyText>
           . Say hello!
         </ContactHeaderText>
       </LandingPageContainer>

--- a/frontend/src/views/ContactUs.tsx
+++ b/frontend/src/views/ContactUs.tsx
@@ -5,6 +5,30 @@ import { LandingPageContainer } from '../components/core/Container';
 import { InlineExternalLink } from '../components/core/Link';
 import { ContactHeaderTitle, ContactHeaderText } from '../components/core/Text';
 
+type CopyIndicator = {
+  copiedEmail: boolean,
+}
+
+const CopyIndicatorContainer = styled.div.attrs((props: CopyIndicator) => ({
+  style: {
+    transform: (!props.copiedEmail) ? 'translateY(-60px)' : null,
+  },
+}))<CopyIndicator>`
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transition: transform 0.25s;
+`;
+
+const CopyIndicator = styled(DefaultButton)`
+  position: relative;
+  left: -50%;
+  margin: 0 auto;
+  padding: 0.25rem 1rem;
+  color: ${({ theme }) => theme.colors.white};
+  background: ${({ theme }) => theme.colors.gradients.green};
+`;
+
 function ContactUsPage() {
   const InlineEmailCopyText = styled(ContactHeaderText)`
     display: inline-block;
@@ -19,30 +43,13 @@ function ContactUsPage() {
 
   const [copiedEmail, setCopiedEmail] = useState<boolean>(false);
 
-  const CopyIndicatorContainer = styled.div`
-    position: absolute;
-    top: 20px;
-    left: 50%;
-  `;
-
-  const CopyIndicator = styled(DefaultButton)`
-    position: relative;
-    left: -50%;
-    margin: 0 auto;
-    padding: 0.25rem 1rem;
-    color: ${({ theme }) => theme.colors.white};
-    background: ${({ theme }) => theme.colors.gradients.green};
-  `;
-
   return (
     <>
-      {copiedEmail ? (
-        <CopyIndicatorContainer>
-          <CopyIndicator onClick={() => setCopiedEmail(false)}>
-            Email copied to clipboard!&nbsp;&nbsp;✕
-          </CopyIndicator>
-        </CopyIndicatorContainer>
-      ) : null}
+      <CopyIndicatorContainer copiedEmail={copiedEmail}>
+        <CopyIndicator onClick={() => setCopiedEmail(false)}>
+          Email copied to clipboard!&nbsp;&nbsp;✕
+        </CopyIndicator>
+      </CopyIndicatorContainer>
       <LandingPageContainer>
         <ContactHeaderTitle>
           Contact Us

--- a/frontend/src/views/ContactUs.tsx
+++ b/frontend/src/views/ContactUs.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { LandingPageContainer } from '../components/core/Container';
+import { ContactHeaderTitle, ContactHeaderText } from '../components/core/Text';
+
+function ContactUsPage() {
+  return (
+    <LandingPageContainer>
+      <ContactHeaderTitle>
+        Contact Us
+      </ContactHeaderTitle>
+      <ContactHeaderText>
+        We are two students building the tool we wish we had when learning computer science.
+      </ContactHeaderText>
+      <ContactHeaderText>
+        You can follow our progress on our
+        {' '}
+        <Link to="https://github.com/rocketden" target="_blank">GitHub</Link>
+        {' '}
+        or our
+        {' '}
+        <Link to="https://trello.com/b/jb0SgY1b/sprint-board" target="_blank">public roadmap on Trello</Link>
+        .
+      </ContactHeaderText>
+      <ContactHeaderText>
+        You can contact us at
+        {' '}
+        <Link to="mailto::support@codejoust.co" target="_blank">support@codejoust.co</Link>
+        . Say hello!
+      </ContactHeaderText>
+    </LandingPageContainer>
+  );
+}
+
+export default ContactUsPage;

--- a/frontend/src/views/ContactUs.tsx
+++ b/frontend/src/views/ContactUs.tsx
@@ -1,9 +1,21 @@
 import React from 'react';
+import styled from 'styled-components';
 import { LandingPageContainer } from '../components/core/Container';
 import { InlineExternalLink } from '../components/core/Link';
-import { ContactHeaderTitle, ContactHeaderText, InlineHeaderCopyText } from '../components/core/Text';
+import { ContactHeaderTitle, ContactHeaderText } from '../components/core/Text';
 
 function ContactUsPage() {
+  const InlineEmailCopyText = styled(ContactHeaderText)`
+    display: inline-block;
+    margin: 0;
+    cursor: pointer;
+    border-bottom: 1px solid ${({ theme }) => theme.colors.text};
+  `;
+
+  const CopyIcon = styled.i`
+    margin-left: 5px;
+  `;
+
   return (
     <LandingPageContainer>
       <ContactHeaderTitle>
@@ -25,12 +37,12 @@ function ContactUsPage() {
       <ContactHeaderText>
         You can contact us at
         {' '}
-        <InlineHeaderCopyText>
+        <InlineEmailCopyText
+          onClick={() => navigator.clipboard.writeText('support@codejoust.co')}
+        >
           support@codejoust.co
-          <span className="material-icons-outlined">
-            content_copy
-          </span>
-        </InlineHeaderCopyText>
+          <CopyIcon className="material-icons">content_copy</CopyIcon>
+        </InlineEmailCopyText>
         . Say hello!
       </ContactHeaderText>
     </LandingPageContainer>

--- a/frontend/src/views/ContactUs.tsx
+++ b/frontend/src/views/ContactUs.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
+import { DefaultButton } from '../components/core/Button';
 import { LandingPageContainer } from '../components/core/Container';
 import { InlineExternalLink } from '../components/core/Link';
 import { ContactHeaderTitle, ContactHeaderText } from '../components/core/Text';
@@ -16,36 +17,65 @@ function ContactUsPage() {
     margin-left: 5px;
   `;
 
+  const [copiedEmail, setCopiedEmail] = useState<boolean>(false);
+
+  const CopyIndicatorContainer = styled.div`
+    position: absolute;
+    top: 20px;
+    left: 50%;
+  `;
+
+  const CopyIndicator = styled(DefaultButton)`
+    position: relative;
+    left: -50%;
+    margin: 0 auto;
+    padding: 0.25rem 1rem;
+    color: ${({ theme }) => theme.colors.white};
+    background: ${({ theme }) => theme.colors.gradients.green};
+  `;
+
   return (
-    <LandingPageContainer>
-      <ContactHeaderTitle>
-        Contact Us
-      </ContactHeaderTitle>
-      <ContactHeaderText>
-        We are two students building the tool we wish we had when learning computer science.
-      </ContactHeaderText>
-      <ContactHeaderText>
-        You can follow our progress on our
-        {' '}
-        <InlineExternalLink href="https://github.com/rocketden" target="_blank">GitHub</InlineExternalLink>
-        {' '}
-        or our
-        {' '}
-        <InlineExternalLink href="https://trello.com/b/jb0SgY1b/sprint-board" target="_blank">public roadmap on Trello</InlineExternalLink>
-        .
-      </ContactHeaderText>
-      <ContactHeaderText>
-        You can contact us at
-        {' '}
-        <InlineEmailCopyText
-          onClick={() => navigator.clipboard.writeText('support@codejoust.co')}
-        >
-          support@codejoust.co
-          <CopyIcon className="material-icons">content_copy</CopyIcon>
-        </InlineEmailCopyText>
-        . Say hello!
-      </ContactHeaderText>
-    </LandingPageContainer>
+    <>
+      {copiedEmail ? (
+        <CopyIndicatorContainer>
+          <CopyIndicator onClick={() => setCopiedEmail(false)}>
+            Email copied to clipboard!&nbsp;&nbsp;✕
+          </CopyIndicator>
+        </CopyIndicatorContainer>
+      ) : null}
+      <LandingPageContainer>
+        <ContactHeaderTitle>
+          Contact Us
+        </ContactHeaderTitle>
+        <ContactHeaderText>
+          We are two students building the tool we wish we had when learning computer science.
+        </ContactHeaderText>
+        <ContactHeaderText>
+          You can follow our progress on our
+          {' '}
+          <InlineExternalLink href="https://github.com/rocketden" target="_blank">GitHub</InlineExternalLink>
+          {' '}
+          or our
+          {' '}
+          <InlineExternalLink href="https://trello.com/b/jb0SgY1b/sprint-board" target="_blank">public roadmap on Trello</InlineExternalLink>
+          .
+        </ContactHeaderText>
+        <ContactHeaderText>
+          You can contact us at
+          {' '}
+          <InlineEmailCopyText
+            onClick={() => {
+              navigator.clipboard.writeText('support@codejoust.co');
+              setCopiedEmail(true);
+            }}
+          >
+            support@codejoust.co
+            <CopyIcon className="material-icons">content_copy</CopyIcon>
+          </InlineEmailCopyText>
+          . Say hello!
+        </ContactHeaderText>
+      </LandingPageContainer>
+    </>
   );
 }
 

--- a/frontend/src/views/ContactUs.tsx
+++ b/frontend/src/views/ContactUs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { LandingPageContainer } from '../components/core/Container';
-import { ContactHeaderTitle, ContactHeaderText } from '../components/core/Text';
+import { InlineExternalLink } from '../components/core/Link';
+import { ContactHeaderTitle, ContactHeaderText, InlineHeaderCopyText } from '../components/core/Text';
 
 function ContactUsPage() {
   return (
@@ -15,17 +15,22 @@ function ContactUsPage() {
       <ContactHeaderText>
         You can follow our progress on our
         {' '}
-        <Link to="https://github.com/rocketden" target="_blank">GitHub</Link>
+        <InlineExternalLink href="https://github.com/rocketden" target="_blank">GitHub</InlineExternalLink>
         {' '}
         or our
         {' '}
-        <Link to="https://trello.com/b/jb0SgY1b/sprint-board" target="_blank">public roadmap on Trello</Link>
+        <InlineExternalLink href="https://trello.com/b/jb0SgY1b/sprint-board" target="_blank">public roadmap on Trello</InlineExternalLink>
         .
       </ContactHeaderText>
       <ContactHeaderText>
         You can contact us at
         {' '}
-        <Link to="mailto::support@codejoust.co" target="_blank">support@codejoust.co</Link>
+        <InlineHeaderCopyText>
+          support@codejoust.co
+          <span className="material-icons-outlined">
+            content_copy
+          </span>
+        </InlineHeaderCopyText>
         . Say hello!
       </ContactHeaderText>
     </LandingPageContainer>


### PR DESCRIPTION
### List of Changes:
- Add the Contact Us page.
- Add "copy email" functionality and animation.

### Notes:
- I had the email copy functionality rather than a `mailto:` link because I find that "open the email client" functionality annoying, and I think [others do too](https://ihatemailto.com/).
- The "copy email" setup could be used on #118 as described at [this discussion](https://github.com/rocketden/main/pull/118#discussion_r595580414), and for the lobby page "copy room link" feature.
- I updated the links to never turn purple and open in external tabs, but didn't style them further as I think that the link color actually fits.
- The [original implementation](https://stackoverflow.com/questions/39501289/in-reactjs-how-to-copy-text-to-clipboard) for copying to the clipboard, so I used the [`react-copy-to-clipboard` npm package instead](https://www.npmjs.com/package/react-copy-to-clipboard).
- I originally tried to add the "copy" icon through [npm](https://www.npmjs.com/package/material-design-icons), but couldn't get it to work, so I added [Google Fonts simply to the `index.html` file](https://developers.google.com/fonts/docs/material_icons#setup_method_1_using_via_google_fonts).
- The "Email copied!" button is never actually removed from the DOM, as I animate it in and out view instead of directly removing it. Thoughts on this @alankbi - is there an easier way to remove it once it's out of view?

### Screencast and Images:

[Screencast of the Contact Us Copy Page Functionality](https://www.loom.com/share/e0c79be40f3b431e81dfbc2752099d33)

**Contact Us Page**
<img width="1123" alt="Screen Shot 2021-03-17 at 6 04 44 PM" src="https://user-images.githubusercontent.com/7987279/111558063-3bc51200-874b-11eb-983b-162316d14573.png">


