### PR TITLE
Design the new lobby page.

### DIFF
--- a/frontend/src/components/card/HostActionCard.tsx
+++ b/frontend/src/components/card/HostActionCard.tsx
@@ -6,13 +6,13 @@ import { User } from '../../api/User';
 const Content = styled.div`
   // Center div above parent
   position: absolute;
-  top: 0;
+  top: -5px;
   left: 50%;
   transform: translate(-50%, 0);
   
   width: 150px;
   background-color: ${({ theme }) => theme.colors.white};
-  border-radius: 5px 5px 0 0;
+  border-radius: 0.5rem;
   box-shadow: 0 -1px 4px rgba(0, 0, 0, 0.12);
   
   height: 20px;

--- a/frontend/src/components/card/HostActionCard.tsx
+++ b/frontend/src/components/card/HostActionCard.tsx
@@ -1,25 +1,40 @@
 import React from 'react';
 import styled from 'styled-components';
-import { SmallActionText } from '../core/Text';
+import { SmallActionHeaderText, SmallActionText } from '../core/Text';
 import { User } from '../../api/User';
 
-const Content = styled.div`
+type PlayerIconType = {
+  isActive: boolean,
+};
+
+const Content = styled.div<PlayerIconType>`
   // Center div above parent
   position: absolute;
-  top: -5px;
+  top: ${({ isActive }) => (isActive ? '-115px' : '-90px')};
   left: 50%;
   transform: translate(-50%, 0);
   
-  width: 150px;
+  width: 120px;
   background-color: ${({ theme }) => theme.colors.white};
   border-radius: 0.5rem;
   box-shadow: 0 -1px 4px rgba(0, 0, 0, 0.12);
   
-  height: 20px;
+  height: ${({ isActive }) => (isActive ? '90px' : '65px')};
   padding: 8px;
-  
-  // -(height + 2 * padding - 3px)
-  margin-top: -36px;
+`;
+
+const ActionCardActiveIcon = styled.div<PlayerIconType>`
+  display: inline-block;
+  margin-right: 5px;
+  background: ${({ theme, isActive }) => (isActive ? theme.colors.gradients.green : theme.colors.gradients.red)};
+  border-radius: 0.5rem;
+  height: 0.5rem;
+  width: 0.5rem;
+`;
+
+const ActionCardSeparator = styled.hr`
+  border: none;
+  border-top: 1px solid ${({ theme }) => theme.colors.text};
 `;
 
 type HostActionCardProps = {
@@ -35,7 +50,10 @@ function HostActionCard(props: HostActionCardProps) {
   } = props;
 
   return (
-    <Content>
+    <Content isActive={userIsActive}>
+      <ActionCardActiveIcon isActive={userIsActive} />
+      <SmallActionHeaderText>{userIsActive ? 'active' : 'inactive'}</SmallActionHeaderText>
+      <ActionCardSeparator />
       {
         // Only show the make host button if user is active
         userIsActive

--- a/frontend/src/components/card/HostActionCard.tsx
+++ b/frontend/src/components/card/HostActionCard.tsx
@@ -10,7 +10,7 @@ type PlayerIconType = {
 const Content = styled.div<PlayerIconType>`
   // Center div above parent
   position: absolute;
-  top: ${({ isActive }) => (isActive ? '-115px' : '-90px')};
+  top: 55px;
   left: 50%;
   transform: translate(-50%, 0);
   
@@ -21,6 +21,9 @@ const Content = styled.div<PlayerIconType>`
   
   height: ${({ isActive }) => (isActive ? '90px' : '65px')};
   padding: 8px;
+
+  z-index: 2;
+  text-align: center;
 `;
 
 const ActionCardActiveIcon = styled.div<PlayerIconType>`

--- a/frontend/src/components/card/PlayerCard.tsx
+++ b/frontend/src/components/card/PlayerCard.tsx
@@ -9,12 +9,10 @@ type ContentProps = {
 
 const Content = styled.div<ContentProps>`
   display: inline-block;
-  position: relative;
-  box-shadow: 0 1px 8px rgb(0 0 0 / 24%);
+  margin: 0.5rem 0.75rem;
   padding: 0.25rem 1rem;
+  box-shadow: 0 1px 8px rgb(0 0 0 / 24%);
   background-color: ${({ theme }) => theme.colors.white};
-
-  // Subtract above border width from border-radius for actual effect 
   border-radius: 1rem;
 `;
 
@@ -33,6 +31,7 @@ const PlayerCardActiveIcon = styled.div<PlayerIconType>`
 
 type PlayerCardProps = {
   user: User,
+  me: boolean,
   isActive: boolean,
   isHost: boolean,
   children: React.ReactNode,
@@ -40,7 +39,7 @@ type PlayerCardProps = {
 
 function PlayerCard(props: PlayerCardProps) {
   const {
-    user, isActive, isHost, children: actionCard,
+    user, me, isActive, isHost, children: actionCard,
   } = props;
 
   const [showActionCard, setShowActionCard] = useState(false);
@@ -57,7 +56,7 @@ function PlayerCard(props: PlayerCardProps) {
       onMouseLeave={() => setShowActionCard(false)}
       isActive={isActive}
     >
-      <UserNicknameText>
+      <UserNicknameText me={me}>
         <PlayerCardActiveIcon isActive={isActive} />
         {user.nickname}
         {isHost ? <InlineHostIcon>flag</InlineHostIcon> : null}

--- a/frontend/src/components/card/PlayerCard.tsx
+++ b/frontend/src/components/card/PlayerCard.tsx
@@ -10,17 +10,25 @@ type ContentProps = {
 const Content = styled.div<ContentProps>`
   display: inline-block;
   position: relative;
-  padding: 10px;
-  background-color: ${({ theme, isActive }) => (isActive ? theme.colors.lightBlue : theme.colors.lightGray)};
-  background-clip: padding-box;
-  
-  // Invisible border to make hover effect last longer
-  border: 15px solid transparent;
-  
-  // Add above border width from margin for actual effect
-  margin: -5px;
+  box-shadow: 0 1px 8px rgb(0 0 0 / 24%);
+  padding: 0.25rem 1rem;
+  background-color: ${({ theme }) => theme.colors.white};
+
   // Subtract above border width from border-radius for actual effect 
-  border-radius: 20px;
+  border-radius: 1rem;
+`;
+
+type PlayerIconType = {
+  isActive: boolean,
+};
+
+const PlayerCardActiveIcon = styled.div<PlayerIconType>`
+  display: inline-block;
+  margin-right: 10px;
+  background: ${({ theme, isActive }) => (isActive ? theme.colors.gradients.green : theme.colors.gradients.red)};
+  border-radius: 1rem;
+  height: 1.3rem;
+  width: 1.3rem;
 `;
 
 type PlayerCardProps = {
@@ -37,6 +45,12 @@ function PlayerCard(props: PlayerCardProps) {
 
   const [showActionCard, setShowActionCard] = useState(false);
 
+  const InlineHostIcon = styled.i.attrs(() => ({
+    className: 'material-icons',
+  }))`
+    margin-left: 5px;
+  `;
+
   return (
     <Content
       onMouseEnter={() => setShowActionCard(true)}
@@ -44,8 +58,9 @@ function PlayerCard(props: PlayerCardProps) {
       isActive={isActive}
     >
       <UserNicknameText>
+        <PlayerCardActiveIcon isActive={isActive} />
         {user.nickname}
-        {isHost ? ' (host)' : ''}
+        {isHost ? <InlineHostIcon>flag</InlineHostIcon> : null}
       </UserNicknameText>
 
       {showActionCard ? actionCard : null}

--- a/frontend/src/components/card/PlayerCard.tsx
+++ b/frontend/src/components/card/PlayerCard.tsx
@@ -8,16 +8,12 @@ const TransparentHoverContainer = styled.div`
   background-clip: padding-box;
 
   // Invisible border to make hover effect last longer
-  border: 5px solid transparent;
-
-  // Undo the margin effects of the invisible border
-  margin: -5px;
+  border: 10px solid transparent;
 `;
 
 const Content = styled.div`
   display: inline-block;
   position: relative;
-  margin: 0.5rem 0.75rem;
   padding: 0.25rem 1rem;
   box-shadow: 0 1px 8px rgb(0 0 0 / 24%);
   background-color: ${({ theme }) => theme.colors.white};

--- a/frontend/src/components/card/PlayerCard.tsx
+++ b/frontend/src/components/card/PlayerCard.tsx
@@ -3,12 +3,20 @@ import styled from 'styled-components';
 import { UserNicknameText } from '../core/Text';
 import { User } from '../../api/User';
 
-type ContentProps = {
-  isActive: boolean,
-};
-
-const Content = styled.div<ContentProps>`
+const TransparentHoverContainer = styled.div`
   display: inline-block;
+  background-clip: padding-box;
+
+  // Invisible border to make hover effect last longer
+  border: 5px solid transparent;
+
+  // Undo the margin effects of the invisible border
+  margin: -5px;
+`;
+
+const Content = styled.div`
+  display: inline-block;
+  position: relative;
   margin: 0.5rem 0.75rem;
   padding: 0.25rem 1rem;
   box-shadow: 0 1px 8px rgb(0 0 0 / 24%);
@@ -51,19 +59,20 @@ function PlayerCard(props: PlayerCardProps) {
   `;
 
   return (
-    <Content
+    <TransparentHoverContainer
       onMouseEnter={() => setShowActionCard(true)}
       onMouseLeave={() => setShowActionCard(false)}
-      isActive={isActive}
     >
-      <UserNicknameText me={me}>
-        <PlayerCardActiveIcon isActive={isActive} />
-        {user.nickname}
-        {isHost ? <InlineHostIcon>flag</InlineHostIcon> : null}
-      </UserNicknameText>
+      <Content>
+        <UserNicknameText me={me}>
+          <PlayerCardActiveIcon isActive={isActive} />
+          {user.nickname}
+          {isHost ? <InlineHostIcon>flag</InlineHostIcon> : null}
+        </UserNicknameText>
 
-      {showActionCard ? actionCard : null}
-    </Content>
+        {showActionCard ? actionCard : null}
+      </Content>
+    </TransparentHoverContainer>
   );
 }
 

--- a/frontend/src/components/config/App.tsx
+++ b/frontend/src/components/config/App.tsx
@@ -15,7 +15,7 @@ import ProblemPage from '../../views/ProblemPage';
 import CreateProblemPage from '../../views/CreateProblemPage';
 import CircleBackgroundLayout from '../layout/CircleBackground';
 import ContactUsPage from '../../views/ContactUs';
-import ProblemLayout from '../layout/ProblemLayout';
+import MinimalLayout from '../layout/MinimalLayout';
 
 function App() {
   return (
@@ -24,11 +24,11 @@ function App() {
       <CustomRoute path="/game" component={GamePage} layout={GameLayout} exact />
       <CustomRoute path="/game/join" component={JoinGamePage} layout={MainLayout} exact />
       <CustomRoute path="/game/create" component={CreateGamePage} layout={MainLayout} exact />
-      <CustomRoute path="/game/lobby" component={LobbyPage} layout={MainLayout} exact />
+      <CustomRoute path="/game/lobby" component={LobbyPage} layout={MinimalLayout} exact />
       <CustomRoute path="/game/results" component={GameResultsPage} layout={MainLayout} exact />
-      <CustomRoute path="/problems/all" component={AllProblemsPage} layout={ProblemLayout} exact />
-      <CustomRoute path="/problem/create" component={CreateProblemPage} layout={ProblemLayout} exact />
-      <CustomRoute path="/problem/:id" component={ProblemPage} layout={ProblemLayout} exact />
+      <CustomRoute path="/problems/all" component={AllProblemsPage} layout={MinimalLayout} exact />
+      <CustomRoute path="/problem/create" component={CreateProblemPage} layout={MinimalLayout} exact />
+      <CustomRoute path="/problem/:id" component={ProblemPage} layout={MinimalLayout} exact />
       <CustomRoute path="/contact-us" component={ContactUsPage} layout={MainLayout} exact />
       <CustomRoute path="*" component={NotFound} layout={MainLayout} />
     </Switch>

--- a/frontend/src/components/config/App.tsx
+++ b/frontend/src/components/config/App.tsx
@@ -3,7 +3,7 @@ import { Switch } from 'react-router-dom';
 import MainLayout from '../layout/Main';
 import LandingPage from '../../views/Landing';
 import NotFound from '../../views/NotFound';
-import CustomRoute from './Route';
+import { CustomRoute, CustomRedirect } from './Route';
 import GamePage from '../../views/Game';
 import GameLayout from '../layout/Game';
 import JoinGamePage from '../../views/Join';
@@ -30,6 +30,7 @@ function App() {
       <CustomRoute path="/problem/create" component={CreateProblemPage} layout={MinimalLayout} exact />
       <CustomRoute path="/problem/:id" component={ProblemPage} layout={MinimalLayout} exact />
       <CustomRoute path="/contact-us" component={ContactUsPage} layout={MainLayout} exact />
+      <CustomRedirect from="/play" to="/game/join" />
       <CustomRoute path="*" component={NotFound} layout={MainLayout} />
     </Switch>
   );

--- a/frontend/src/components/config/Route.tsx
+++ b/frontend/src/components/config/Route.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { Redirect, Route } from 'react-router-dom';
 
-function CustomRoute(props: any) {
+export function CustomRoute(props: any) {
   const { component: Component, layout: Layout, ...rest } = props;
   return (
     <Route
@@ -15,4 +15,11 @@ function CustomRoute(props: any) {
   );
 }
 
-export default CustomRoute;
+// Redirect preserving the query string.
+export function CustomRedirect(props: any) {
+  const { to, from, location } = props;
+  const newTo: string = `${to}${location.search}`;
+  return (
+    <Redirect to={newTo} from={from} />
+  );
+}

--- a/frontend/src/components/config/Theme.tsx
+++ b/frontend/src/components/config/Theme.tsx
@@ -43,7 +43,6 @@ export const ThemeConfig: any = {
     large: '1.8rem',
     xLarge: '2rem',
     xxLarge: '2.5rem',
-    largest: '2.8rem',
     globalDefault: '16px',
     globalSmall: '14px',
   },

--- a/frontend/src/components/config/Theme.tsx
+++ b/frontend/src/components/config/Theme.tsx
@@ -43,6 +43,7 @@ export const ThemeConfig: any = {
     large: '1.8rem',
     xLarge: '2rem',
     xxLarge: '2.5rem',
+    largest: '2.8rem',
     globalDefault: '16px',
     globalSmall: '14px',
   },

--- a/frontend/src/components/config/Theme.tsx
+++ b/frontend/src/components/config/Theme.tsx
@@ -10,6 +10,7 @@ export const ThemeConfig: any = {
     background: '#f8f8f8',
     border: '#ccc',
     lightBlue: '#AED2EA',
+    sliderBlue: '#B7D4FF',
     blue: '#3E93CD',
     darkBlue: '#2E7DB2',
     red: 'red',

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -101,6 +101,10 @@ export const SmallDifficultyButton = styled(DefaultButton)<DifficultyProps>`
   }
 `;
 
+export const SmallDifficultyButtonNoMargin = styled(SmallDifficultyButton)`
+  margin: 0;
+`;
+
 export const DifficultyButton = styled(DefaultButton)<DifficultyProps>`
   font-size: ${({ theme }) => theme.fontSize.mediumLarge};
   background: ${({ active, difficulty, theme }) => (active ? difficultyToColor[difficulty].background : theme.colors.white)};

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -31,6 +31,7 @@ export const PrimaryButton = styled(DefaultButton)<any>`
   min-height: 40px;
 
   &:disabled {
+    opacity: 0.5;
     background: ${({ theme }) => theme.colors.gradients.gray};
 
     &:hover {
@@ -77,10 +78,11 @@ export const SmallDifficultyButton = styled(DefaultButton)<DifficultyProps>`
   margin: 0.5rem 1rem 0 0;
 
   &:disabled {
-    background-color: ${({ theme }) => theme.colors.gray};
+    opacity: 0.5;
 
     &:hover {
       cursor: default;
+      opacity: 0.5;
       box-shadow: 0 1px 8px rgba(0, 0, 0, 0.24);
     }
   }

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -31,7 +31,7 @@ export const PrimaryButton = styled(DefaultButton)<any>`
   min-height: 40px;
 
   &:disabled {
-    background-color: ${({ theme }) => theme.colors.gray};
+    background: ${({ theme }) => theme.colors.gradients.gray};
 
     &:hover {
       cursor: default;

--- a/frontend/src/components/core/HoverTooltip.tsx
+++ b/frontend/src/components/core/HoverTooltip.tsx
@@ -1,0 +1,43 @@
+import styled from "styled-components";
+
+type HoverTooltipType = {
+  x: number,
+  y: number,
+  visible: boolean,
+}
+
+export const HoverTooltip = styled.div.attrs((props: HoverTooltipType) => ({
+  style: {
+    display: `${props.visible ? 'block' : 'none'}`,
+    transform: `translate(${props.x + 2}px, ${props.y + 2}px)`,
+  },
+}))<HoverTooltipType>`
+  z-index: 3;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  background: ${({ theme }) => theme.colors.text};
+  color: ${({ theme }) => theme.colors.white};
+  font-size: ${({ theme }) => theme.fontSize.medium};
+  position: absolute;
+  top: 0;
+  left: 0;
+`;
+
+export const HoverContainer = styled.div`
+  position: relative;
+  padding: 0;
+  display: inline-block;
+`;
+
+type HoverElementDisplay = {
+  enabled: boolean,
+}
+
+export const HoverElement = styled.div.attrs((props: HoverElementDisplay) => ({
+  style: {
+    display: `${props.enabled ? 'none' : 'block'}`,
+  },
+}))<HoverElementDisplay>`
+  position: absolute;
+  z-index: 1;
+`;

--- a/frontend/src/components/core/RangeSlider.tsx
+++ b/frontend/src/components/core/RangeSlider.tsx
@@ -45,4 +45,14 @@ export const Slider = styled.input.attrs((props: SliderRange) => ({
     background: linear-gradient(180deg, #133ED7 0%, #90BDFF 100%);
     cursor: pointer;
   }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.5;
+
+    &:hover {
+      cursor: default;
+      opacity: 0.5;
+    }
+  }
 `;

--- a/frontend/src/components/core/RangeSlider.tsx
+++ b/frontend/src/components/core/RangeSlider.tsx
@@ -15,6 +15,7 @@ export const Slider = styled.input.attrs((props: SliderRange) => ({
   value: props.value,
 }))<SliderRange>`
   -webkit-appearance: none;
+  max-width: 370px;
   width: 100%;
   height: 15px;
   border-radius: 5px;

--- a/frontend/src/components/core/RangeSlider.tsx
+++ b/frontend/src/components/core/RangeSlider.tsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+
+export const SliderContainer = styled.div`
+  width: 100%;
+  margin: 0.5rem 0;
+`;
+
+type SliderRange = {
+  value: number,
+};
+
+export const Slider = styled.input.attrs((props: SliderRange) => ({
+  type: 'range',
+  class: 'slider',
+  value: props.value,
+}))<SliderRange>`
+  -webkit-appearance: none;
+  width: 100%;
+  height: 15px;
+  border-radius: 5px;
+  background: #B7D4FF;
+  outline: none;
+  opacity: 0.7;
+  -webkit-transition: .2s;
+  transition: opacity .2s;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 25px;
+    height: 25px;
+    border-radius: 10px;
+    background: linear-gradient(180deg, #133ED7 0%, #90BDFF 100%);
+    cursor: pointer;
+  }
+
+  &::-moz-range-thumb {
+    width: 25px;
+    height: 25px;
+    border-radius: 10px;
+    background: linear-gradient(180deg, #133ED7 0%, #90BDFF 100%);
+    cursor: pointer;
+  }
+`;

--- a/frontend/src/components/core/RangeSlider.tsx
+++ b/frontend/src/components/core/RangeSlider.tsx
@@ -47,11 +47,17 @@ export const Slider = styled.input.attrs((props: SliderRange) => ({
   }
 
   &:disabled {
-    cursor: default;
     opacity: 0.5;
 
-    &:hover {
+    &::-webkit-slider-thumb {
       cursor: default;
+    }
+
+    &::-moz-range-thumb {
+      cursor: default;
+    }
+
+    &:hover {
       opacity: 0.5;
     }
   }

--- a/frontend/src/components/core/RangeSlider.tsx
+++ b/frontend/src/components/core/RangeSlider.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const SliderContainer = styled.div`
   width: 100%;
-  margin: 0.5rem 0;
+  margin: 0;
 `;
 
 type SliderRange = {

--- a/frontend/src/components/core/RangeSlider.tsx
+++ b/frontend/src/components/core/RangeSlider.tsx
@@ -18,7 +18,7 @@ export const Slider = styled.input.attrs((props: SliderRange) => ({
   width: 100%;
   height: 15px;
   border-radius: 5px;
-  background: #B7D4FF;
+  background: ${({ theme }) => theme.colors.sliderBlue};
   outline: none;
   opacity: 0.7;
   -webkit-transition: .2s;
@@ -34,7 +34,7 @@ export const Slider = styled.input.attrs((props: SliderRange) => ({
     width: 25px;
     height: 25px;
     border-radius: 10px;
-    background: linear-gradient(180deg, #133ED7 0%, #90BDFF 100%);
+    background: ${({ theme }) => theme.colors.gradients.blue};
     cursor: pointer;
   }
 
@@ -42,7 +42,7 @@ export const Slider = styled.input.attrs((props: SliderRange) => ({
     width: 25px;
     height: 25px;
     border-radius: 10px;
-    background: linear-gradient(180deg, #133ED7 0%, #90BDFF 100%);
+    background: ${({ theme }) => theme.colors.gradients.blue};
     cursor: pointer;
   }
 

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -68,9 +68,13 @@ export const ContactHeaderText = styled.h1`
   font-weight: 400;
 `;
 
-export const UserNicknameText = styled(Text)`
+type NicknameType = {
+  me: boolean,
+};
+
+export const UserNicknameText = styled(Text)<NicknameType>`
   font-size: ${({ theme }) => theme.fontSize.large};
-  font-weight: 400;
+  font-weight: ${({ me }) => (me ? 700 : 400)};
   margin: 0;
 `;
 

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -32,6 +32,11 @@ export const SmallHeaderText = styled.p`
   margin: 10px 0;
 `;
 
+export const NoMarginSubtitleText = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.mediumLarge};
+  margin: 0;
+`;
+
 export const MediumText = styled.h5`
   font-size: ${({ theme }) => theme.fontSize.xMediumLarge};
 `;

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -83,11 +83,15 @@ export const ProblemHeaderText = styled.h2`
   color: ${({ theme }) => theme.colors.darkText};
 `;
 
+export const SmallActionHeaderText = styled.p`
+  display: inline-block;
+  font-size: ${({ theme }) => theme.fontSize.medium};
+  margin: 0;
+`;
+
 export const SmallActionText = styled.p`
-  font-size: ${({ theme }) => theme.fontSize.mediumSmall};
-  display: inline;
-  margin: 1px 4px;
-  padding: 2px 4px;
+  font-size: ${({ theme }) => theme.fontSize.medium};
+  margin: 2px 0px;
 
   &:hover {
     cursor: pointer;

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -36,9 +36,12 @@ export const MediumText = styled.h5`
   font-size: ${({ theme }) => theme.fontSize.xMediumLarge};
 `;
 
-export const LowMarginMediumText = styled.h5`
-  font-size: ${({ theme }) => theme.fontSize.xMediumLarge};
+export const LowMarginMediumText = styled(MediumText)`
   margin: 1rem 0;
+`;
+
+export const NoMarginMediumText = styled(MediumText)`
+  margin: 0;
 `;
 
 export const LargeText = styled.h3`

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -68,7 +68,9 @@ export const ContactHeaderText = styled.h1`
   font-weight: 400;
 `;
 
-export const UserNicknameText = styled(LargeText)`
+export const UserNicknameText = styled(Text)`
+  font-size: ${({ theme }) => theme.fontSize.large};
+  font-weight: 400;
   margin: 0;
 `;
 

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -51,7 +51,7 @@ export const LandingHeaderTitle = styled.h1`
   font-weight: 700;
 `;
 
-export const LandingHeaderText = styled.h1`
+export const MainHeaderText = styled.h1`
   font-size: ${({ theme }) => theme.fontSize.xMediumLarge};
   font-weight: 400;
 `;

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -64,6 +64,11 @@ export const MainHeaderText = styled.h1`
   font-weight: 400;
 `;
 
+export const SecondaryHeaderText = styled.h1`
+  font-size: ${({ theme }) => theme.fontSize.mediumLarge};
+  font-weight: 400;
+`;
+
 export const ContactHeaderTitle = styled.h1`
   font-size: ${({ theme }) => theme.fontSize.xLarge};
   color: ${({ theme }) => theme.colors.darkText};

--- a/frontend/src/components/layout/MinimalLayout.tsx
+++ b/frontend/src/components/layout/MinimalLayout.tsx
@@ -14,7 +14,7 @@ type MyProps = {
   children: React.ReactNode,
 }
 
-function ProblemLayout({ children }: MyProps) {
+function MinimalLayout({ children }: MyProps) {
   return (
     <Content>
       <MinimalHeader />
@@ -25,4 +25,4 @@ function ProblemLayout({ children }: MyProps) {
   );
 }
 
-export default ProblemLayout;
+export default MinimalLayout;

--- a/frontend/src/components/special/CopyIndicator.tsx
+++ b/frontend/src/components/special/CopyIndicator.tsx
@@ -36,7 +36,8 @@ export const InlineCopyText = styled(ContactHeaderText)`
 export const InlineBackgroundCopyText = styled(ContactHeaderText)`
   display: inline-block;
   margin: 0;
-  padding: 0.25rem 1rem;
+  padding: 0.25rem 0.5rem;
+  font-size: ${({ theme }) => theme.fontSize.mediumLarge};
   background: ${({ theme }) => theme.colors.text};
   color: ${({ theme }) => theme.colors.white};
   border-radius: 0.5rem;
@@ -46,5 +47,6 @@ export const InlineBackgroundCopyText = styled(ContactHeaderText)`
 export const InlineCopyIcon = styled.i.attrs(() => ({
   className: 'material-icons',
 }))`
+  font-size: ${({ theme }) => theme.fontSize.mediumLarge};
   margin-left: 5px;
 `;

--- a/frontend/src/components/special/CopyIndicator.tsx
+++ b/frontend/src/components/special/CopyIndicator.tsx
@@ -33,6 +33,16 @@ export const InlineCopyText = styled(ContactHeaderText)`
   border-bottom: 1px solid ${({ theme }) => theme.colors.text};
 `;
 
+export const InlineBackgroundCopyText = styled(ContactHeaderText)`
+  display: inline-block;
+  margin: 0;
+  padding: 0.25rem 1rem;
+  background: ${({ theme }) => theme.colors.text};
+  color: ${({ theme }) => theme.colors.white};
+  border-radius: 0.5rem;
+  cursor: pointer;
+`;
+
 export const InlineCopyIcon = styled.i.attrs(() => ({
   className: 'material-icons',
 }))`

--- a/frontend/src/components/special/IdContainer.tsx
+++ b/frontend/src/components/special/IdContainer.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const NumberContainer = styled.div`
+  display: inline-block;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+  padding: 0.5rem 1rem;
+  margin: 0 1rem 0 0;
+  font-size: ${({ theme }) => theme.fontSize.largest};
+  font-weight: 700;
+  border-radius: 0.5rem;
+`;
+
+type IdProps = {
+  id: string,
+};
+
+function IdContainer(props: IdProps) {
+  const { id } = props;
+
+  return (
+    <div>
+      {
+        id.split('').map((c, index) => {
+          if (id.length - 1 === index) {
+            return <NumberContainer style={{ margin: 0 }}>{c}</NumberContainer>;
+          }
+          return <NumberContainer>{c}</NumberContainer>;
+        })
+      }
+    </div>
+  );
+}
+
+export default IdContainer;

--- a/frontend/src/components/special/IdContainer.tsx
+++ b/frontend/src/components/special/IdContainer.tsx
@@ -7,7 +7,7 @@ const NumberContainer = styled.div`
   padding: 0.5rem 1rem;
   margin: 0 1rem 0 0;
   background: ${({ theme }) => theme.colors.white};
-  font-size: ${({ theme }) => theme.fontSize.xxLarge};
+  font-size: ${({ theme }) => theme.fontSize.xLarge};
   font-weight: 700;
   border-radius: 0.5rem;
 `;

--- a/frontend/src/components/special/IdContainer.tsx
+++ b/frontend/src/components/special/IdContainer.tsx
@@ -6,7 +6,7 @@ const NumberContainer = styled.div`
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
   padding: 0.5rem 1rem;
   margin: 0 1rem 0 0;
-  font-size: ${({ theme }) => theme.fontSize.largest};
+  font-size: ${({ theme }) => theme.fontSize.xxLarge};
   font-weight: 700;
   border-radius: 0.5rem;
 `;

--- a/frontend/src/components/special/IdContainer.tsx
+++ b/frontend/src/components/special/IdContainer.tsx
@@ -6,6 +6,7 @@ const NumberContainer = styled.div`
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
   padding: 0.5rem 1rem;
   margin: 0 1rem 0 0;
+  background: ${({ theme }) => theme.colors.white};
   font-size: ${({ theme }) => theme.fontSize.xxLarge};
   font-weight: 700;
   border-radius: 0.5rem;

--- a/frontend/src/views/Landing.tsx
+++ b/frontend/src/views/Landing.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ThemeConfig } from '../components/config/Theme';
 import { PrimaryButtonLink, TextLink } from '../components/core/Link';
-import { LandingHeaderText, LandingHeaderTitle } from '../components/core/Text';
+import { MainHeaderText, LandingHeaderTitle } from '../components/core/Text';
 
 function LandingPage() {
   return (
@@ -9,9 +9,9 @@ function LandingPage() {
       <LandingHeaderTitle>
         CodeJoust
       </LandingHeaderTitle>
-      <LandingHeaderText>
+      <MainHeaderText>
         Compete live against friends and classmates to solve coding challenges.
-      </LandingHeaderText>
+      </MainHeaderText>
       <PrimaryButtonLink
         color={ThemeConfig.colors.gradients.blue}
         to="/game/create"

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -98,6 +98,7 @@ function LobbyPage() {
 
   // Set all the different variables in the room object
   const [host, setHost] = useState<User | null>(null);
+  const [users, setUsers] = useState<User[] | null>(null);
   const [activeUsers, setActiveUsers] = useState<User[] | null>(null);
   const [inactiveUsers, setInactiveUsers] = useState<User[] | null>(null);
   const [currentRoomId, setRoomId] = useState('');
@@ -125,6 +126,7 @@ function LobbyPage() {
    */
   const setStateFromRoom = (room: Room) => {
     setHost(room.host);
+    setUsers(room.users);
     setActiveUsers(room.activeUsers);
     setInactiveUsers(room.inactiveUsers);
     setRoomId(room.roomId);
@@ -438,8 +440,8 @@ function LobbyPage() {
           <SmallHeaderTextZeroTopMargin>
             Players
             {
-              (activeUsers && inactiveUsers)
-                ? ` (${activeUsers.length + inactiveUsers.length})`
+              users
+                ? ` (${users.length})`
                 : null
             }
           </SmallHeaderTextZeroTopMargin>

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -5,8 +5,8 @@ import styled from 'styled-components';
 import copy from 'copy-to-clipboard';
 import ErrorMessage from '../components/core/Error';
 import {
+  NoMarginMediumText,
   MainHeaderText,
-  MediumText,
   SmallHeaderText,
   Text,
 } from '../components/core/Text';
@@ -16,7 +16,7 @@ import {
 import { User } from '../api/User';
 import { checkLocationState, isValidRoomId } from '../util/Utility';
 import { Difficulty } from '../api/Difficulty';
-import { PrimaryButton, DifficultyButton } from '../components/core/Button';
+import { PrimaryButton, SmallDifficultyButton } from '../components/core/Button';
 import Loading from '../components/core/Loading';
 import PlayerCard from '../components/card/PlayerCard';
 import HostActionCard from '../components/card/HostActionCard';
@@ -78,10 +78,14 @@ const SmallHeaderTextZeroTopMargin = styled(SmallHeaderText)`
 const BackgroundContainer = styled.div`
   height: 12rem;
   background: ${({ theme }) => theme.colors.white};
-  padding: 0.5rem;
+  padding: 1rem;
   box-shadow: 0 -1px 4px rgba(0, 0, 0, 0.12);
   border-radius: 0.75rem;
   overflow: auto;
+`;
+
+const DifficultyContainer = styled.div`
+  margin-bottom: 10px;
 `;
 
 function LobbyPage() {
@@ -452,58 +456,57 @@ function LobbyPage() {
         <OptionsContainer>
           <SmallHeaderTextZeroTopMargin>Options</SmallHeaderTextZeroTopMargin>
           <BackgroundContainer>
-            Test
+            <NoMarginMediumText>Difficulty</NoMarginMediumText>
+            <DifficultyContainer>
+              {Object.keys(Difficulty).map((key) => {
+                const difficultyKey: Difficulty = Difficulty[key as keyof typeof Difficulty];
+                return (
+                  <SmallDifficultyButton
+                    difficulty={difficultyKey}
+                    onClick={() => updateDifficultySetting(key)}
+                    active={difficulty === difficultyKey}
+                    enabled={isHost(currentUser)}
+                    title={!isHost(currentUser) ? 'Only the host can change these settings' : undefined}
+                  >
+                    {key}
+                  </SmallDifficultyButton>
+                );
+              })}
+            </DifficultyContainer>
+            <NoMarginMediumText>Duration</NoMarginMediumText>
+            <Text>
+              {isHost(currentUser) ? 'Choose a game duration between 1-60 minutes:'
+                : 'The game will last for the following minutes:'}
+            </Text>
+            <NumberInput
+              min={1}
+              max={60}
+              value={duration}
+              disabled={!isHost(currentUser)}
+              onKeyPress={(e) => {
+                // Prevent user from using any of these non-numeric characters
+                if (e.key === 'e' || e.key === '.' || e.key === '-') {
+                  e.preventDefault();
+                }
+              }}
+              onChange={(e) => {
+                const { value } = e.target;
+
+                // Set duration to undefined to allow users to clear field
+                if (!value) {
+                  setDuration(undefined);
+                } else {
+                  const newDuration = Number(value);
+                  if (newDuration >= 0 && newDuration <= 60) {
+                    setDuration(newDuration);
+                  }
+                }
+              }}
+              onBlur={updateRoomDuration}
+            />
           </BackgroundContainer>
         </OptionsContainer>
       </FlexBareContainerLeft>
-
-      <MediumText>Difficulty Settings</MediumText>
-      {Object.keys(Difficulty).map((key) => {
-        const difficultyKey: Difficulty = Difficulty[key as keyof typeof Difficulty];
-        return (
-          <DifficultyButton
-            difficulty={difficultyKey}
-            onClick={() => updateDifficultySetting(key)}
-            active={difficulty === difficultyKey}
-            enabled={isHost(currentUser)}
-            title={!isHost(currentUser) ? 'Only the host can change these settings' : undefined}
-          >
-            {key}
-          </DifficultyButton>
-        );
-      })}
-
-      <MediumText>Duration</MediumText>
-      <Text>
-        {isHost(currentUser) ? 'Choose a game duration between 1-60 minutes:'
-          : 'The game will last for the following minutes:'}
-      </Text>
-      <NumberInput
-        min={1}
-        max={60}
-        value={duration}
-        disabled={!isHost(currentUser)}
-        onKeyPress={(e) => {
-          // Prevent user from using any of these non-numeric characters
-          if (e.key === 'e' || e.key === '.' || e.key === '-') {
-            e.preventDefault();
-          }
-        }}
-        onChange={(e) => {
-          const { value } = e.target;
-
-          // Set duration to undefined to allow users to clear field
-          if (!value) {
-            setDuration(undefined);
-          } else {
-            const newDuration = Number(value);
-            if (newDuration >= 0 && newDuration <= 60) {
-              setDuration(newDuration);
-            }
-          }
-        }}
-        onBlur={updateRoomDuration}
-      />
     </>
   );
 }

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -8,7 +8,7 @@ import {
   NoMarginMediumText,
   MainHeaderText,
   SmallHeaderText,
-  Text,
+  NoMarginSubtitleText,
 } from '../components/core/Text';
 import {
   connect, routes, subscribe, disconnect,
@@ -24,7 +24,6 @@ import { startGame } from '../api/Game';
 import {
   getRoom, Room, changeRoomHost, updateRoomSettings, removeUser,
 } from '../api/Room';
-import { NumberInput } from '../components/core/Input';
 import { errorHandler } from '../api/Error';
 import {
   CopyIndicator,
@@ -34,6 +33,7 @@ import {
 } from '../components/special/CopyIndicator';
 import IdContainer from '../components/special/IdContainer';
 import { FlexBareContainer } from '../components/core/Container';
+import { Slider, SliderContainer } from '../components/core/RangeSlider';
 
 type LobbyPageLocation = {
   user: User,
@@ -474,36 +474,31 @@ function LobbyPage() {
               })}
             </DifficultyContainer>
             <NoMarginMediumText>Duration</NoMarginMediumText>
-            <Text>
-              {isHost(currentUser) ? 'Choose a game duration between 1-60 minutes:'
-                : 'The game will last for the following minutes:'}
-            </Text>
-            <NumberInput
-              min={1}
-              max={60}
-              value={duration}
-              disabled={!isHost(currentUser)}
-              onKeyPress={(e) => {
-                // Prevent user from using any of these non-numeric characters
-                if (e.key === 'e' || e.key === '.' || e.key === '-') {
-                  e.preventDefault();
-                }
-              }}
-              onChange={(e) => {
-                const { value } = e.target;
+            <NoMarginSubtitleText>
+              {`${duration} minutes`}
+            </NoMarginSubtitleText>
+            <SliderContainer>
+              <Slider
+                min={1}
+                max={60}
+                value={duration}
+                disabled={!isHost(currentUser)}
+                onChange={(e) => {
+                  const { value } = e.target;
 
-                // Set duration to undefined to allow users to clear field
-                if (!value) {
-                  setDuration(undefined);
-                } else {
-                  const newDuration = Number(value);
-                  if (newDuration >= 0 && newDuration <= 60) {
-                    setDuration(newDuration);
+                  // Set duration to undefined to allow users to clear field
+                  if (!value) {
+                    setDuration(undefined);
+                  } else {
+                    const newDuration = Number(value);
+                    if (newDuration >= 0 && newDuration <= 60) {
+                      setDuration(newDuration);
+                      updateRoomDuration();
+                    }
                   }
-                }
-              }}
-              onBlur={updateRoomDuration}
-            />
+                }}
+              />
+            </SliderContainer>
           </BackgroundContainer>
         </OptionsContainer>
       </FlexBareContainerLeft>

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import { Message, Subscription } from 'stompjs';
+import styled from 'styled-components';
 import ErrorMessage from '../components/core/Error';
 import { LargeText, MediumText, Text } from '../components/core/Text';
 import {
@@ -25,6 +26,11 @@ type LobbyPageLocation = {
   user: User,
   roomId: string,
 };
+
+const HeaderContainer = styled.div`
+  width: 80%;
+  margin: 0 auto;
+`;
 
 function LobbyPage() {
   // Get history object to be able to move between different pages
@@ -331,15 +337,17 @@ function LobbyPage() {
 
   // Render the lobby.
   return (
-    <div>
-      <LargeText>
-        You have entered the lobby for room
-        {' #'}
-        {currentRoomId}
-        ! Your nickname is &quot;
-        {currentUser?.nickname}
-        &quot;.
-      </LargeText>
+    <>
+      <HeaderContainer>
+        <LargeText>
+          You have entered the lobby for room
+          {' #'}
+          {currentRoomId}
+          ! Your nickname is &quot;
+          {currentUser?.nickname}
+          &quot;.
+        </LargeText>
+      </HeaderContainer>
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }
 
@@ -412,7 +420,7 @@ function LobbyPage() {
           </PrimaryButton>
         )
         : <MediumText>Waiting for the host to start the game...</MediumText>}
-    </div>
+    </>
   );
 }
 

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -233,6 +233,7 @@ function LobbyPage() {
       return userList.map((user) => (
         <PlayerCard
           user={user}
+          me={currentUser !== null && (user.nickname === currentUser.nickname)}
           isHost={isHost(user)}
           isActive={isActive}
         >

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -479,7 +479,7 @@ function LobbyPage() {
         x={mousePosition.x}
         y={mousePosition.y}
       >
-        Only the host can start the game
+        Only the host can start the game and update settings
       </HoverTooltip>
       <CopyIndicatorContainer copied={copiedRoomLink}>
         <CopyIndicator onClick={() => setCopiedRoomLink(false)}>

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -35,6 +35,7 @@ import IdContainer from '../components/special/IdContainer';
 import { FlexBareContainer } from '../components/core/Container';
 import { Slider, SliderContainer } from '../components/core/RangeSlider';
 import { Coordinate } from '../components/special/FloatingCircle';
+import { HoverContainer, HoverElement, HoverTooltip } from '../components/core/HoverTooltip';
 
 type LobbyPageLocation = {
   user: User,
@@ -88,48 +89,6 @@ const BackgroundContainer = styled.div`
 
 const DifficultyContainer = styled.div`
   margin-bottom: 10px;
-`;
-
-type HoverTooltipType = {
-  x: number,
-  y: number,
-  visible: boolean,
-}
-
-const HoverTooltip = styled.div.attrs((props: HoverTooltipType) => ({
-  style: {
-    display: `${props.visible ? 'block' : 'none'}`,
-    transform: `translate(${props.x + 2}px, ${props.y + 2}px)`,
-  },
-}))<HoverTooltipType>`
-  z-index: 3;
-  padding: 0.25rem;
-  border-radius: 0.25rem;
-  background: ${({ theme }) => theme.colors.text};
-  color: ${({ theme }) => theme.colors.white};
-  font-size: ${({ theme }) => theme.fontSize.medium};
-  position: absolute;
-  top: 0;
-  left: 0;
-`;
-
-const HoverContainer = styled.div`
-  position: relative;
-  padding: 0;
-  display: inline-block;
-`;
-
-type HoverElementDisplay = {
-  enabled: boolean,
-}
-
-const HoverElement = styled.div.attrs((props: HoverElementDisplay) => ({
-  style: {
-    display: `${props.enabled ? 'none' : 'block'}`,
-  },
-}))<HoverElementDisplay>`
-  position: absolute;
-  z-index: 1;
 `;
 
 const HoverContainerPrimaryButton = styled(HoverContainer)`

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -16,7 +16,7 @@ import {
 import { User } from '../api/User';
 import { checkLocationState, isValidRoomId } from '../util/Utility';
 import { Difficulty } from '../api/Difficulty';
-import { PrimaryButton, SmallDifficultyButton } from '../components/core/Button';
+import { PrimaryButton, SmallDifficultyButtonNoMargin } from '../components/core/Button';
 import Loading from '../components/core/Loading';
 import PlayerCard from '../components/card/PlayerCard';
 import HostActionCard from '../components/card/HostActionCard';
@@ -114,9 +114,20 @@ const HoverTooltip = styled.div.attrs((props: HoverTooltipType) => ({
 `;
 
 const HoverContainer = styled.div`
-  margin: 1.2rem 0;
   padding: 0;
   display: inline-block;
+`;
+
+const HoverContainerPrimaryButton = styled(HoverContainer)`
+  margin: 1.2rem 0;
+`;
+
+const HoverContainerSmallDifficultyButton = styled(HoverContainer)`
+  margin: 0.5rem 1rem 0 0;
+`;
+
+const HoverContainerSlider = styled(HoverContainer)`
+  margin: 0.5rem 0;
 `;
 
 function LobbyPage() {
@@ -482,7 +493,7 @@ function LobbyPage() {
           with Room ID:
         </SecondaryHeaderText>
         <IdContainer id={currentRoomId} />
-        <HoverContainer
+        <HoverContainerPrimaryButton
           onMouseEnter={() => {
             if (!isHost(currentUser)) {
               setHoverVisible(true);
@@ -501,7 +512,7 @@ function LobbyPage() {
           >
             Start Game
           </PrimaryButtonNoMargin>
-        </HoverContainer>
+        </HoverContainerPrimaryButton>
 
       </HeaderContainer>
 
@@ -534,13 +545,7 @@ function LobbyPage() {
               {Object.keys(Difficulty).map((key) => {
                 const difficultyKey: Difficulty = Difficulty[key as keyof typeof Difficulty];
                 return (
-                  <SmallDifficultyButton
-                    difficulty={difficultyKey}
-                    onClick={() => updateDifficultySetting(key)}
-                    active={difficulty === difficultyKey}
-                    enabled={isHost(currentUser)}
-                    disabled={!isHost(currentUser)}
-                    title={!isHost(currentUser) ? 'Only the host can change these settings' : undefined}
+                  <HoverContainerSmallDifficultyButton
                     onMouseEnter={() => {
                       if (!isHost(currentUser)) {
                         setHoverVisible(true);
@@ -552,8 +557,17 @@ function LobbyPage() {
                       }
                     }}
                   >
-                    {key}
-                  </SmallDifficultyButton>
+                    <SmallDifficultyButtonNoMargin
+                      difficulty={difficultyKey}
+                      onClick={() => updateDifficultySetting(key)}
+                      active={difficulty === difficultyKey}
+                      enabled={isHost(currentUser)}
+                      disabled={!isHost(currentUser)}
+                      title={!isHost(currentUser) ? 'Only the host can change these settings' : undefined}
+                    >
+                      {key}
+                    </SmallDifficultyButtonNoMargin>
+                  </HoverContainerSmallDifficultyButton>
                 );
               })}
             </DifficultyContainer>
@@ -561,39 +575,42 @@ function LobbyPage() {
             <NoMarginSubtitleText>
               {`${duration} minutes`}
             </NoMarginSubtitleText>
-            <SliderContainer>
-              <Slider
-                min={1}
-                max={60}
-                value={duration}
-                disabled={!isHost(currentUser)}
-                title={!isHost(currentUser) ? 'Only the host can change these settings' : undefined}
-                onMouseEnter={() => {
-                  if (!isHost(currentUser)) {
-                    setHoverVisible(true);
-                  }
-                }}
-                onMouseLeave={() => {
-                  if (!isHost(currentUser)) {
-                    setHoverVisible(false);
-                  }
-                }}
-                onChange={(e) => {
-                  const { value } = e.target;
+            <HoverContainerSlider
+              onMouseEnter={() => {
+                if (!isHost(currentUser)) {
+                  setHoverVisible(true);
+                }
+              }}
+              onMouseLeave={() => {
+                if (!isHost(currentUser)) {
+                  setHoverVisible(false);
+                }
+              }}
+            >
+              <SliderContainer>
+                <Slider
+                  min={1}
+                  max={60}
+                  value={duration}
+                  disabled={!isHost(currentUser)}
+                  title={!isHost(currentUser) ? 'Only the host can change these settings' : undefined}
+                  onChange={(e) => {
+                    const { value } = e.target;
 
-                  // Set duration to undefined to allow users to clear field
-                  if (!value) {
-                    setDuration(undefined);
-                  } else {
-                    const newDuration = Number(value);
-                    if (newDuration >= 0 && newDuration <= 60) {
-                      setDuration(newDuration);
+                    // Set duration to undefined to allow users to clear field
+                    if (!value) {
+                      setDuration(undefined);
+                    } else {
+                      const newDuration = Number(value);
+                      if (newDuration >= 0 && newDuration <= 60) {
+                        setDuration(newDuration);
+                      }
                     }
-                  }
-                }}
-                onMouseUp={updateRoomDuration}
-              />
-            </SliderContainer>
+                  }}
+                  onMouseUp={updateRoomDuration}
+                />
+              </SliderContainer>
+            </HoverContainerSlider>
           </BackgroundContainer>
         </RoomSettingsContainer>
       </FlexBareContainerLeft>

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -4,7 +4,12 @@ import { Message, Subscription } from 'stompjs';
 import styled from 'styled-components';
 import copy from 'copy-to-clipboard';
 import ErrorMessage from '../components/core/Error';
-import { MainHeaderText, MediumText, Text } from '../components/core/Text';
+import {
+  MainHeaderText,
+  MediumText,
+  SmallHeaderText,
+  Text,
+} from '../components/core/Text';
 import {
   connect, routes, subscribe, disconnect,
 } from '../api/Socket';
@@ -28,6 +33,7 @@ import {
   InlineBackgroundCopyText,
 } from '../components/special/CopyIndicator';
 import IdContainer from '../components/special/IdContainer';
+import { FlexBareContainer } from '../components/core/Container';
 
 type LobbyPageLocation = {
   user: User,
@@ -37,7 +43,7 @@ type LobbyPageLocation = {
 const HeaderContainer = styled.div`
   text-align: left;
   width: 66%;
-  margin: 2rem auto;
+  margin: 2rem auto 0;
 
   @media (max-width: 750px) {
     width: 80%;
@@ -49,6 +55,29 @@ const HeaderContainer = styled.div`
 
 const PrimaryButtonZeroLeftMargin = styled(PrimaryButton)`
   margin-left: 0;
+`;
+
+const FlexBareContainerLeft = styled(FlexBareContainer)`
+  text-align: left;
+`;
+
+const PlayersContainer = styled.div`
+  flex: 6;
+  padding-right: 5px;
+`;
+
+const OptionsContainer = styled.div`
+  flex: 4;
+  padding-left: 5px;
+`;
+
+const BackgroundContainer = styled.div`
+  height: 12rem;
+  background: ${({ theme }) => theme.colors.white};
+  padding: 0.5rem;
+  box-shadow: 0 -1px 4px rgba(0, 0, 0, 0.12);
+  border-radius: 0.75rem;
+  overflow: auto;
 `;
 
 function LobbyPage() {
@@ -394,17 +423,35 @@ function LobbyPage() {
           Start Game
         </PrimaryButtonZeroLeftMargin>
       </HeaderContainer>
-      { error ? <ErrorMessage message={error} /> : null }
-      { loading ? <Loading /> : null }
 
-      <div>
-        {
-          displayUsers(activeUsers, true)
-        }
-        {
-          displayUsers(inactiveUsers, false)
-        }
-      </div>
+      <FlexBareContainerLeft>
+        <PlayersContainer>
+          <SmallHeaderText>
+            Players
+            {
+              (activeUsers && inactiveUsers)
+                ? ` (${activeUsers.length + inactiveUsers.length})`
+                : null
+            }
+          </SmallHeaderText>
+          <BackgroundContainer>
+            {
+              displayUsers(activeUsers, true)
+            }
+            {
+              displayUsers(inactiveUsers, false)
+            }
+            { error ? <ErrorMessage message={error} /> : null }
+            { loading ? <Loading /> : null }
+          </BackgroundContainer>
+        </PlayersContainer>
+        <OptionsContainer>
+          <SmallHeaderText>Options</SmallHeaderText>
+          <BackgroundContainer>
+            Test
+          </BackgroundContainer>
+        </OptionsContainer>
+      </FlexBareContainerLeft>
 
       <MediumText>Difficulty Settings</MediumText>
       {Object.keys(Difficulty).map((key) => {

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -66,7 +66,7 @@ const PlayersContainer = styled.div`
   padding-right: 5px;
 `;
 
-const OptionsContainer = styled.div`
+const RoomSettingsContainer = styled.div`
   flex: 4;
   padding-left: 5px;
 `;
@@ -427,6 +427,7 @@ function LobbyPage() {
         <PrimaryButtonZeroLeftMargin
           onClick={handleStartGame}
           disabled={loading || !isHost(currentUser)}
+          title={!isHost(currentUser) ? 'Only the host can start the game' : undefined}
         >
           Start Game
         </PrimaryButtonZeroLeftMargin>
@@ -453,8 +454,8 @@ function LobbyPage() {
             { loading ? <Loading /> : null }
           </BackgroundContainer>
         </PlayersContainer>
-        <OptionsContainer>
-          <SmallHeaderTextZeroTopMargin>Options</SmallHeaderTextZeroTopMargin>
+        <RoomSettingsContainer>
+          <SmallHeaderTextZeroTopMargin>Room Settings</SmallHeaderTextZeroTopMargin>
           <BackgroundContainer>
             <NoMarginMediumText>Difficulty</NoMarginMediumText>
             <DifficultyContainer>
@@ -466,6 +467,7 @@ function LobbyPage() {
                     onClick={() => updateDifficultySetting(key)}
                     active={difficulty === difficultyKey}
                     enabled={isHost(currentUser)}
+                    disabled={!isHost(currentUser)}
                     title={!isHost(currentUser) ? 'Only the host can change these settings' : undefined}
                   >
                     {key}
@@ -483,6 +485,7 @@ function LobbyPage() {
                 max={60}
                 value={duration}
                 disabled={!isHost(currentUser)}
+                title={!isHost(currentUser) ? 'Only the host can change these settings' : undefined}
                 onChange={(e) => {
                   const { value } = e.target;
 
@@ -493,14 +496,14 @@ function LobbyPage() {
                     const newDuration = Number(value);
                     if (newDuration >= 0 && newDuration <= 60) {
                       setDuration(newDuration);
-                      updateRoomDuration();
                     }
                   }
                 }}
+                onMouseUp={updateRoomDuration}
               />
             </SliderContainer>
           </BackgroundContainer>
-        </OptionsContainer>
+        </RoomSettingsContainer>
       </FlexBareContainerLeft>
     </>
   );

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -119,13 +119,21 @@ const HoverContainer = styled.div`
   display: inline-block;
 `;
 
-const HoverElement = styled.div`
+type HoverElementDisplay = {
+  enabled: boolean,
+}
+
+const HoverElement = styled.div.attrs((props: HoverElementDisplay) => ({
+  style: {
+    display: `${props.enabled ? 'none' : 'block'}`,
+  },
+}))<HoverElementDisplay>`
   position: absolute;
   z-index: 1;
 `;
 
 const HoverContainerPrimaryButton = styled(HoverContainer)`
-  margin: 1.2rem 0;
+  margin: 1.2rem 1.2rem 1.2rem 0;
 `;
 
 const HoverElementPrimaryButton = styled(HoverElement)`
@@ -510,6 +518,7 @@ function LobbyPage() {
         <IdContainer id={currentRoomId} />
         <HoverContainerPrimaryButton>
           <HoverElementPrimaryButton
+            enabled={!isHost(currentUser)}
             onMouseEnter={() => {
               if (!isHost(currentUser)) {
                 setHoverVisible(true);
@@ -562,6 +571,7 @@ function LobbyPage() {
                 return (
                   <HoverContainerSmallDifficultyButton>
                     <HoverElementSmallDifficultyButton
+                      enabled={!isHost(currentUser)}
                       onMouseEnter={() => {
                         if (!isHost(currentUser)) {
                           setHoverVisible(true);
@@ -592,6 +602,7 @@ function LobbyPage() {
             </NoMarginSubtitleText>
             <HoverContainerSlider>
               <HoverElementSlider
+                enabled={!isHost(currentUser)}
                 onMouseEnter={() => {
                   if (!isHost(currentUser)) {
                     setHoverVisible(true);

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -34,6 +34,7 @@ import {
 import IdContainer from '../components/special/IdContainer';
 import { FlexBareContainer } from '../components/core/Container';
 import { Slider, SliderContainer } from '../components/core/RangeSlider';
+import { Coordinate } from '../components/special/FloatingCircle';
 
 type LobbyPageLocation = {
   user: User,
@@ -54,8 +55,8 @@ const HeaderContainer = styled.div`
   }
 `;
 
-const PrimaryButtonZeroLeftMargin = styled(PrimaryButton)`
-  margin-left: 0;
+const PrimaryButtonNoMargin = styled(PrimaryButton)`
+  margin: 0;
 `;
 
 const FlexBareContainerLeft = styled(FlexBareContainer)`
@@ -89,6 +90,35 @@ const DifficultyContainer = styled.div`
   margin-bottom: 10px;
 `;
 
+type HoverTooltipType = {
+  x: number,
+  y: number,
+  visible: boolean,
+}
+
+const HoverTooltip = styled.div.attrs((props: HoverTooltipType) => ({
+  style: {
+    display: `${props.visible ? 'block' : 'none'}`,
+    transform: `translate(${props.x + 2}px, ${props.y + 2}px)`,
+  },
+}))<HoverTooltipType>`
+  z-index: 3;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  background: ${({ theme }) => theme.colors.text};
+  color: ${({ theme }) => theme.colors.white};
+  font-size: ${({ theme }) => theme.fontSize.medium};
+  position: absolute;
+  top: 0;
+  left: 0;
+`;
+
+const HoverContainer = styled.div`
+  margin: 1.2rem 0;
+  padding: 0;
+  display: inline-block;
+`;
+
 function LobbyPage() {
   // Get history object to be able to move between different pages
   const history = useHistory();
@@ -106,6 +136,8 @@ function LobbyPage() {
   const [active, setActive] = useState(false);
   const [difficulty, setDifficulty] = useState<Difficulty | null>(null);
   const [duration, setDuration] = useState<number | undefined>(15);
+  const [mousePosition, setMousePosition] = useState<Coordinate>({ x: 0, y: 0 });
+  const [hoverVisible, setHoverVisible] = useState<boolean>(false);
 
   // Hold error text.
   const [error, setError] = useState('');
@@ -353,6 +385,15 @@ function LobbyPage() {
     });
   }, [currentUser, conditionallyBootKickedUser]);
 
+  // Get current mouse position.
+  const mouseMoveHandler = useCallback((e: MouseEvent) => {
+    setMousePosition({ x: e.clientX, y: e.clientY });
+  }, [setMousePosition]);
+
+  useEffect(() => {
+    window.onmousemove = mouseMoveHandler;
+  }, [mouseMoveHandler]);
+
   // Grab the nickname variable and add the user to the lobby.
   useEffect(() => {
     // Grab the user and room information; otherwise, redirect to the join page
@@ -400,6 +441,20 @@ function LobbyPage() {
   // Render the lobby.
   return (
     <>
+      <HoverTooltip
+        visible={hoverVisible}
+        x={mousePosition.x}
+        y={mousePosition.y}
+      >
+        Only the host can start the game
+      </HoverTooltip>
+      <HoverTooltip
+        visible
+        x={400}
+        y={400}
+      >
+        This is a test.
+      </HoverTooltip>
       <CopyIndicatorContainer copied={copiedRoomLink}>
         <CopyIndicator onClick={() => setCopiedRoomLink(false)}>
           Link copied!&nbsp;&nbsp;✕
@@ -427,13 +482,27 @@ function LobbyPage() {
           with Room ID:
         </SecondaryHeaderText>
         <IdContainer id={currentRoomId} />
-        <PrimaryButtonZeroLeftMargin
-          onClick={handleStartGame}
-          disabled={loading || !isHost(currentUser)}
-          title={!isHost(currentUser) ? 'Only the host can start the game' : undefined}
+        <HoverContainer
+          onMouseEnter={() => {
+            if (!isHost(currentUser)) {
+              setHoverVisible(true);
+            }
+          }}
+          onMouseLeave={() => {
+            if (!isHost(currentUser)) {
+              setHoverVisible(false);
+            }
+          }}
         >
-          Start Game
-        </PrimaryButtonZeroLeftMargin>
+          <PrimaryButtonNoMargin
+            onClick={handleStartGame}
+            disabled={loading || !isHost(currentUser)}
+            title={!isHost(currentUser) ? 'Only the host can start the game' : undefined}
+          >
+            Start Game
+          </PrimaryButtonNoMargin>
+        </HoverContainer>
+
       </HeaderContainer>
 
       <FlexBareContainerLeft>
@@ -472,6 +541,16 @@ function LobbyPage() {
                     enabled={isHost(currentUser)}
                     disabled={!isHost(currentUser)}
                     title={!isHost(currentUser) ? 'Only the host can change these settings' : undefined}
+                    onMouseEnter={() => {
+                      if (!isHost(currentUser)) {
+                        setHoverVisible(true);
+                      }
+                    }}
+                    onMouseLeave={() => {
+                      if (!isHost(currentUser)) {
+                        setHoverVisible(false);
+                      }
+                    }}
                   >
                     {key}
                   </SmallDifficultyButton>
@@ -489,6 +568,16 @@ function LobbyPage() {
                 value={duration}
                 disabled={!isHost(currentUser)}
                 title={!isHost(currentUser) ? 'Only the host can change these settings' : undefined}
+                onMouseEnter={() => {
+                  if (!isHost(currentUser)) {
+                    setHoverVisible(true);
+                  }
+                }}
+                onMouseLeave={() => {
+                  if (!isHost(currentUser)) {
+                    setHoverVisible(false);
+                  }
+                }}
                 onChange={(e) => {
                   const { value } = e.target;
 

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -71,7 +71,7 @@ const RoomSettingsContainer = styled.div`
   padding-left: 5px;
 `;
 
-const SmallHeaderTextZeroTopMargin = styled(SmallHeaderText)`
+const LobbyContainerTitle = styled(SmallHeaderText)`
   margin: 0 0 10px 0;
 `;
 
@@ -437,14 +437,14 @@ function LobbyPage() {
 
       <FlexBareContainerLeft>
         <PlayersContainer>
-          <SmallHeaderTextZeroTopMargin>
+          <LobbyContainerTitle>
             Players
             {
               users
                 ? ` (${users.length})`
                 : null
             }
-          </SmallHeaderTextZeroTopMargin>
+          </LobbyContainerTitle>
           <BackgroundContainer>
             {
               displayUsers(activeUsers, true)
@@ -457,7 +457,7 @@ function LobbyPage() {
           </BackgroundContainer>
         </PlayersContainer>
         <RoomSettingsContainer>
-          <SmallHeaderTextZeroTopMargin>Room Settings</SmallHeaderTextZeroTopMargin>
+          <LobbyContainerTitle>Room Settings</LobbyContainerTitle>
           <BackgroundContainer>
             <NoMarginMediumText>Difficulty</NoMarginMediumText>
             <DifficultyContainer>

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -151,6 +151,7 @@ const HoverElementSmallDifficultyButton = styled(HoverElement)`
 `;
 
 const HoverContainerSlider = styled(HoverContainer)`
+  width: 100%;
   margin: 0.5rem 0;
 `;
 
@@ -518,7 +519,7 @@ function LobbyPage() {
         <IdContainer id={currentRoomId} />
         <HoverContainerPrimaryButton>
           <HoverElementPrimaryButton
-            enabled={!isHost(currentUser)}
+            enabled={isHost(currentUser)}
             onMouseEnter={() => {
               if (!isHost(currentUser)) {
                 setHoverVisible(true);
@@ -571,7 +572,7 @@ function LobbyPage() {
                 return (
                   <HoverContainerSmallDifficultyButton>
                     <HoverElementSmallDifficultyButton
-                      enabled={!isHost(currentUser)}
+                      enabled={isHost(currentUser)}
                       onMouseEnter={() => {
                         if (!isHost(currentUser)) {
                           setHoverVisible(true);
@@ -602,7 +603,7 @@ function LobbyPage() {
             </NoMarginSubtitleText>
             <HoverContainerSlider>
               <HoverElementSlider
-                enabled={!isHost(currentUser)}
+                enabled={isHost(currentUser)}
                 onMouseEnter={() => {
                   if (!isHost(currentUser)) {
                     setHoverVisible(true);

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -71,6 +71,10 @@ const OptionsContainer = styled.div`
   padding-left: 5px;
 `;
 
+const SmallHeaderTextZeroTopMargin = styled(SmallHeaderText)`
+  margin: 0 0 10px 0;
+`;
+
 const BackgroundContainer = styled.div`
   height: 12rem;
   background: ${({ theme }) => theme.colors.white};
@@ -426,14 +430,14 @@ function LobbyPage() {
 
       <FlexBareContainerLeft>
         <PlayersContainer>
-          <SmallHeaderText>
+          <SmallHeaderTextZeroTopMargin>
             Players
             {
               (activeUsers && inactiveUsers)
                 ? ` (${activeUsers.length + inactiveUsers.length})`
                 : null
             }
-          </SmallHeaderText>
+          </SmallHeaderTextZeroTopMargin>
           <BackgroundContainer>
             {
               displayUsers(activeUsers, true)
@@ -446,7 +450,7 @@ function LobbyPage() {
           </BackgroundContainer>
         </PlayersContainer>
         <OptionsContainer>
-          <SmallHeaderText>Options</SmallHeaderText>
+          <SmallHeaderTextZeroTopMargin>Options</SmallHeaderTextZeroTopMargin>
           <BackgroundContainer>
             Test
           </BackgroundContainer>

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -114,20 +114,42 @@ const HoverTooltip = styled.div.attrs((props: HoverTooltipType) => ({
 `;
 
 const HoverContainer = styled.div`
+  position: relative;
   padding: 0;
   display: inline-block;
+`;
+
+const HoverElement = styled.div`
+  position: absolute;
+  z-index: 1;
 `;
 
 const HoverContainerPrimaryButton = styled(HoverContainer)`
   margin: 1.2rem 0;
 `;
 
+const HoverElementPrimaryButton = styled(HoverElement)`
+  width: 10rem;
+  height: 2.75rem;
+`;
+
 const HoverContainerSmallDifficultyButton = styled(HoverContainer)`
   margin: 0.5rem 1rem 0 0;
 `;
 
+const HoverElementSmallDifficultyButton = styled(HoverElement)`
+  width: 5rem;
+  height: 2rem;
+`;
+
 const HoverContainerSlider = styled(HoverContainer)`
   margin: 0.5rem 0;
+`;
+
+const HoverElementSlider = styled(HoverElement)`
+  max-width: 370px;
+  width: 100%;
+  height: 20px;
 `;
 
 function LobbyPage() {
@@ -459,13 +481,6 @@ function LobbyPage() {
       >
         Only the host can start the game
       </HoverTooltip>
-      <HoverTooltip
-        visible
-        x={400}
-        y={400}
-      >
-        This is a test.
-      </HoverTooltip>
       <CopyIndicatorContainer copied={copiedRoomLink}>
         <CopyIndicator onClick={() => setCopiedRoomLink(false)}>
           Link copied!&nbsp;&nbsp;✕
@@ -493,18 +508,19 @@ function LobbyPage() {
           with Room ID:
         </SecondaryHeaderText>
         <IdContainer id={currentRoomId} />
-        <HoverContainerPrimaryButton
-          onMouseEnter={() => {
-            if (!isHost(currentUser)) {
-              setHoverVisible(true);
-            }
-          }}
-          onMouseLeave={() => {
-            if (!isHost(currentUser)) {
-              setHoverVisible(false);
-            }
-          }}
-        >
+        <HoverContainerPrimaryButton>
+          <HoverElementPrimaryButton
+            onMouseEnter={() => {
+              if (!isHost(currentUser)) {
+                setHoverVisible(true);
+              }
+            }}
+            onMouseLeave={() => {
+              if (!isHost(currentUser)) {
+                setHoverVisible(false);
+              }
+            }}
+          />
           <PrimaryButtonNoMargin
             onClick={handleStartGame}
             disabled={loading || !isHost(currentUser)}
@@ -545,18 +561,19 @@ function LobbyPage() {
               {Object.keys(Difficulty).map((key) => {
                 const difficultyKey: Difficulty = Difficulty[key as keyof typeof Difficulty];
                 return (
-                  <HoverContainerSmallDifficultyButton
-                    onMouseEnter={() => {
-                      if (!isHost(currentUser)) {
-                        setHoverVisible(true);
-                      }
-                    }}
-                    onMouseLeave={() => {
-                      if (!isHost(currentUser)) {
-                        setHoverVisible(false);
-                      }
-                    }}
-                  >
+                  <HoverContainerSmallDifficultyButton>
+                    <HoverElementSmallDifficultyButton
+                      onMouseEnter={() => {
+                        if (!isHost(currentUser)) {
+                          setHoverVisible(true);
+                        }
+                      }}
+                      onMouseLeave={() => {
+                        if (!isHost(currentUser)) {
+                          setHoverVisible(false);
+                        }
+                      }}
+                    />
                     <SmallDifficultyButtonNoMargin
                       difficulty={difficultyKey}
                       onClick={() => updateDifficultySetting(key)}
@@ -575,18 +592,19 @@ function LobbyPage() {
             <NoMarginSubtitleText>
               {`${duration} minutes`}
             </NoMarginSubtitleText>
-            <HoverContainerSlider
-              onMouseEnter={() => {
-                if (!isHost(currentUser)) {
-                  setHoverVisible(true);
-                }
-              }}
-              onMouseLeave={() => {
-                if (!isHost(currentUser)) {
-                  setHoverVisible(false);
-                }
-              }}
-            >
+            <HoverContainerSlider>
+              <HoverElementSlider
+                onMouseEnter={() => {
+                  if (!isHost(currentUser)) {
+                    setHoverVisible(true);
+                  }
+                }}
+                onMouseLeave={() => {
+                  if (!isHost(currentUser)) {
+                    setHoverVisible(false);
+                  }
+                }}
+              />
               <SliderContainer>
                 <Slider
                   min={1}

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -21,13 +21,13 @@ import {
 } from '../api/Room';
 import { NumberInput } from '../components/core/Input';
 import { errorHandler } from '../api/Error';
-import { ThemeConfig } from '../components/config/Theme';
 import {
   CopyIndicator,
   CopyIndicatorContainer,
   InlineCopyIcon,
   InlineBackgroundCopyText,
 } from '../components/special/CopyIndicator';
+import IdContainer from '../components/special/IdContainer';
 
 type LobbyPageLocation = {
   user: User,
@@ -35,8 +35,20 @@ type LobbyPageLocation = {
 };
 
 const HeaderContainer = styled.div`
-  width: 70%;
+  text-align: left;
+  width: 66%;
   margin: 2rem auto;
+
+  @media (max-width: 750px) {
+    width: 80%;
+  }
+  @media (max-width: 600px) {
+    width: 100%;
+  }
+`;
+
+const PrimaryButtonZeroLeftMargin = styled(PrimaryButton)`
+  margin-left: 0;
 `;
 
 function LobbyPage() {
@@ -373,9 +385,14 @@ function LobbyPage() {
           <i>codejoust.co/play</i>
           {' '}
           with Room ID:
-          {' '}
-          {currentRoomId || 'loading...'}
         </MainHeaderText>
+        <IdContainer id={currentRoomId} />
+        <PrimaryButtonZeroLeftMargin
+          onClick={handleStartGame}
+          disabled={loading || !isHost(currentUser)}
+        >
+          Start Game
+        </PrimaryButtonZeroLeftMargin>
       </HeaderContainer>
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }
@@ -436,19 +453,6 @@ function LobbyPage() {
         }}
         onBlur={updateRoomDuration}
       />
-      <br />
-
-      {isHost(currentUser)
-        ? (
-          <PrimaryButton
-            color={ThemeConfig.colors.gradients.blue}
-            onClick={handleStartGame}
-            disabled={loading}
-          >
-            Start Game
-          </PrimaryButton>
-        )
-        : <MediumText>Waiting for the host to start the game...</MediumText>}
     </>
   );
 }

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -6,7 +6,7 @@ import copy from 'copy-to-clipboard';
 import ErrorMessage from '../components/core/Error';
 import {
   NoMarginMediumText,
-  MainHeaderText,
+  SecondaryHeaderText,
   SmallHeaderText,
   NoMarginSubtitleText,
 } from '../components/core/Text';
@@ -41,6 +41,7 @@ type LobbyPageLocation = {
 };
 
 const HeaderContainer = styled.div`
+  max-width: 500px;
   text-align: left;
   width: 66%;
   margin: 2rem auto 0;
@@ -62,12 +63,12 @@ const FlexBareContainerLeft = styled(FlexBareContainer)`
 `;
 
 const PlayersContainer = styled.div`
-  flex: 6;
+  flex: 1;
   padding-right: 5px;
 `;
 
 const RoomSettingsContainer = styled.div`
-  flex: 4;
+  flex: 1;
   padding-left: 5px;
 `;
 
@@ -76,7 +77,7 @@ const LobbyContainerTitle = styled(SmallHeaderText)`
 `;
 
 const BackgroundContainer = styled.div`
-  height: 12rem;
+  height: 16rem;
   background: ${({ theme }) => theme.colors.white};
   padding: 1rem;
   box-shadow: 0 -1px 4px rgba(0, 0, 0, 0.12);
@@ -405,7 +406,7 @@ function LobbyPage() {
         </CopyIndicator>
       </CopyIndicatorContainer>
       <HeaderContainer>
-        <MainHeaderText>
+        <SecondaryHeaderText>
           Join with the link
           {' '}
           <InlineBackgroundCopyText
@@ -424,7 +425,7 @@ function LobbyPage() {
           <i>codejoust.co/play</i>
           {' '}
           with Room ID:
-        </MainHeaderText>
+        </SecondaryHeaderText>
         <IdContainer id={currentRoomId} />
         <PrimaryButtonZeroLeftMargin
           onClick={handleStartGame}

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -359,7 +359,7 @@ function LobbyPage() {
           {' '}
           <InlineBackgroundCopyText
             onClick={() => {
-              copy(`codejoust.co/play?room=${currentRoomId}`);
+              copy(`https://codejoust.co/play?room=${currentRoomId}`);
               setCopiedRoomLink(true);
             }}
           >

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -524,7 +524,6 @@ function LobbyPage() {
           <PrimaryButtonNoMargin
             onClick={handleStartGame}
             disabled={loading || !isHost(currentUser)}
-            title={!isHost(currentUser) ? 'Only the host can start the game' : undefined}
           >
             Start Game
           </PrimaryButtonNoMargin>
@@ -580,7 +579,6 @@ function LobbyPage() {
                       active={difficulty === difficultyKey}
                       enabled={isHost(currentUser)}
                       disabled={!isHost(currentUser)}
-                      title={!isHost(currentUser) ? 'Only the host can change these settings' : undefined}
                     >
                       {key}
                     </SmallDifficultyButtonNoMargin>
@@ -611,7 +609,6 @@ function LobbyPage() {
                   max={60}
                   value={duration}
                   disabled={!isHost(currentUser)}
-                  title={!isHost(currentUser) ? 'Only the host can change these settings' : undefined}
                   onChange={(e) => {
                     const { value } = e.target;
 

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -2,8 +2,9 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import { Message, Subscription } from 'stompjs';
 import styled from 'styled-components';
+import copy from 'copy-to-clipboard';
 import ErrorMessage from '../components/core/Error';
-import { LargeText, MediumText, Text } from '../components/core/Text';
+import { MainHeaderText, MediumText, Text } from '../components/core/Text';
 import {
   connect, routes, subscribe, disconnect,
 } from '../api/Socket';
@@ -21,6 +22,12 @@ import {
 import { NumberInput } from '../components/core/Input';
 import { errorHandler } from '../api/Error';
 import { ThemeConfig } from '../components/config/Theme';
+import {
+  CopyIndicator,
+  CopyIndicatorContainer,
+  InlineCopyIcon,
+  InlineBackgroundCopyText,
+} from '../components/special/CopyIndicator';
 
 type LobbyPageLocation = {
   user: User,
@@ -28,8 +35,8 @@ type LobbyPageLocation = {
 };
 
 const HeaderContainer = styled.div`
-  width: 80%;
-  margin: 0 auto;
+  width: 70%;
+  margin: 2rem auto;
 `;
 
 function LobbyPage() {
@@ -60,6 +67,9 @@ function LobbyPage() {
 
   // Variable to hold the subscription return, which can be unsubscribed.
   const [subscription, setSubscription] = useState<Subscription | null>(null);
+
+  // Variable to hold whether the room link was copied.
+  const [copiedRoomLink, setCopiedRoomLink] = useState<boolean>(false);
 
   /**
    * Set state variables from an updated room object
@@ -338,15 +348,34 @@ function LobbyPage() {
   // Render the lobby.
   return (
     <>
+      <CopyIndicatorContainer copied={copiedRoomLink}>
+        <CopyIndicator onClick={() => setCopiedRoomLink(false)}>
+          Link copied!&nbsp;&nbsp;✕
+        </CopyIndicator>
+      </CopyIndicatorContainer>
       <HeaderContainer>
-        <LargeText>
-          You have entered the lobby for room
-          {' #'}
-          {currentRoomId}
-          ! Your nickname is &quot;
-          {currentUser?.nickname}
-          &quot;.
-        </LargeText>
+        <MainHeaderText>
+          Join with the link
+          {' '}
+          <InlineBackgroundCopyText
+            onClick={() => {
+              copy(`codejoust.co/play?room=${currentRoomId}`);
+              setCopiedRoomLink(true);
+            }}
+          >
+            codejoust.co/play?room=
+            {currentRoomId}
+            <InlineCopyIcon>content_copy</InlineCopyIcon>
+          </InlineBackgroundCopyText>
+          {' '}
+          or at
+          {' '}
+          <i>codejoust.co/play</i>
+          {' '}
+          with Room ID:
+          {' '}
+          {currentRoomId || 'loading...'}
+        </MainHeaderText>
       </HeaderContainer>
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }

--- a/frontend/src/views/NotFound.tsx
+++ b/frontend/src/views/NotFound.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { TextLink } from '../components/core/Link';
-import { LandingHeaderText } from '../components/core/Text';
+import { MainHeaderText } from '../components/core/Text';
 
 function NotFound() {
   return (
     <div>
-      <LandingHeaderText>
+      <MainHeaderText>
         Uh oh! Page not found
-      </LandingHeaderText>
+      </MainHeaderText>
       <TextLink to="/">
         Click here to return to home &#8594;
       </TextLink>


### PR DESCRIPTION
### List of Changes:
- Update the lobby page to match the [Figma design](https://www.figma.com/file/RqMbCSJslbRDilJScKCVib/RocketDen?node-id=0%3A1).
- Create a slider component for room duration.
- Add custom redirect from `/play?[querystring]` to `/game/join?[querystring]`.
- Add disabled button styling.

### Notes:
- Question: Should the "Room ID" cards have a white or transparent background? Not sure of my preference, so I wanted to check and see your thoughts @alankbi.
- The current user's name is bolded - there may be a better way to symbolize this. We could also allow hovers for non-hosts, which could hold additional information like the active status, the host, and which user is "me".
- I got the slider from [this w3schools tutorial](https://www.w3schools.com/howto/tryit.asp?filename=tryhow_css_js_rangeslider_round) - I couldn't figure out how to style the background for only the first portion, so the entire background is blue. I was also going to have it in increments of 5, but since it starts at 1, this wouldn't work well without some tweaking.
- I tried to make the page not have any scroll, but this was difficult; I may be able to do this by putting the site into vertical flex components, but I think that should be in another PR instead of this one.
- I struggled with the overflow problem on the players container, as I want the player cards to be `overflow: auto` but the hover action item cards to go out of the box. I ended up placing these action cards _below_ the player cards so they would simply show up within the overflow container, as I couldn't solve it despite [research and attempts](https://css-tricks.com/popping-hidden-overflow/), but in a future PR we could update this.
- I didn't add several of the features that are in the [Figma](https://www.figma.com/file/RqMbCSJslbRDilJScKCVib/RocketDen?node-id=0%3A1) as the backend implementation for those are not yet present.
- Similar to the problem page, this doesn't work _great_ with smaller screen sizes (especially very small ones), but it doesn't completely break. There may be a PR in the future to fix the mobile styling for both of those pages.

### Screencast and Images:

[Screencast of the New Lobby Page Design](https://www.loom.com/share/b4adc77f85484aa581320cca357f7b4f)

**New Lobby Page Design**
<img width="1280" alt="New Lobby Page Design" src="https://user-images.githubusercontent.com/7987279/111770523-c13de480-8867-11eb-988d-10c28ce50922.png">

