### PR TITLE
Add refresh and leave / delete room to lobby page.

### DIFF
--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -158,3 +158,21 @@ export const InvertedSmallButton = styled(SmallButton)`
   color: ${({ theme }) => theme.colors.text};
   background: ${({ theme }) => theme.colors.background};
 `;
+
+export const InlineRefreshIcon = styled.i.attrs(() => ({
+  className: 'material-icons',
+}))`
+  display: inline-block;
+  margin: 0 0 0 10px;
+  padding: 0.25rem;
+  border-radius: 1rem;
+  font-size: ${({ theme }) => theme.fontSize.default};
+  background: ${({ theme }) => theme.colors.white};
+  box-shadow: 0 1px 8px rgba(0, 0, 0, 0.24);
+  color: ${({ theme }) => theme.colors.font};
+
+  &:hover {
+    cursor: pointer;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.24);
+  }
+`;

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -43,7 +43,7 @@ export const PrimaryButton = styled(DefaultButton)<any>`
 
 export const SecondaryRedButton = styled(PrimaryButton)<any>`
   background: ${({ theme }) => theme.colors.white};
-  color: ${({ theme }) => theme.colors.red};
+  color: ${({ theme }) => theme.colors.red2};
   margin: 1.2rem 0;
 `;
 

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -41,6 +41,12 @@ export const PrimaryButton = styled(DefaultButton)<any>`
   }
 `;
 
+export const SecondaryRedButton = styled(PrimaryButton)<any>`
+  background: ${({ theme }) => theme.colors.white};
+  color: ${({ theme }) => theme.colors.red};
+  margin: 1.2rem 0;
+`;
+
 export const TextButton = styled.button<ThemeType>`
   background: none;
   border: none;

--- a/frontend/src/components/core/HoverTooltip.tsx
+++ b/frontend/src/components/core/HoverTooltip.tsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+type HoverTooltipType = {
+  x: number,
+  y: number,
+  visible: boolean,
+}
+
+export const HoverTooltip = styled.div.attrs((props: HoverTooltipType) => ({
+  style: {
+    display: `${props.visible ? 'block' : 'none'}`,
+    transform: `translate(${props.x + 2}px, ${props.y + 2}px)`,
+  },
+}))<HoverTooltipType>`
+  z-index: 3;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  background: ${({ theme }) => theme.colors.text};
+  color: ${({ theme }) => theme.colors.white};
+  font-size: ${({ theme }) => theme.fontSize.medium};
+  position: absolute;
+  top: 0;
+  left: 0;
+`;
+
+export const HoverContainer = styled.div`
+  position: relative;
+  padding: 0;
+  display: inline-block;
+`;
+
+type HoverElementDisplay = {
+  enabled: boolean,
+}
+
+export const HoverElement = styled.div.attrs((props: HoverElementDisplay) => ({
+  style: {
+    display: `${props.enabled ? 'none' : 'block'}`,
+  },
+}))<HoverElementDisplay>`
+  position: absolute;
+  z-index: 1;
+`;

--- a/frontend/src/components/core/RangeSlider.tsx
+++ b/frontend/src/components/core/RangeSlider.tsx
@@ -47,11 +47,17 @@ export const Slider = styled.input.attrs((props: SliderRange) => ({
   }
 
   &:disabled {
-    cursor: default;
     opacity: 0.5;
 
-    &:hover {
+    &::-webkit-slider-thumb {
       cursor: default;
+    }
+
+    &::-moz-range-thumb {
+      cursor: default;
+    }
+
+    &:hover {
       opacity: 0.5;
     }
   }

--- a/frontend/src/views/Landing.tsx
+++ b/frontend/src/views/Landing.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ThemeConfig } from '../components/config/Theme';
 import { PrimaryButtonLink, TextLink } from '../components/core/Link';
 import { MainHeaderText, LandingHeaderTitle } from '../components/core/Text';
 
@@ -13,7 +12,8 @@ function LandingPage() {
         Compete live against friends and classmates to solve coding challenges.
       </MainHeaderText>
       <PrimaryButtonLink
-        color={ThemeConfig.colors.gradients.blue}
+        width="12rem"
+        height="3.25rem"
         to="/game/create"
       >
         Create a room

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -341,11 +341,13 @@ function LobbyPage() {
       conditionallyBootKickedUser(room, currentUser);
     };
 
+    setLoading(true);
     connect(roomId, userId).then(() => {
       // Body encrypt through JSON.
       subscribe(routes(roomId).subscribe_lobby, subscribeCallback).then((subscriptionParam) => {
         setSubscription(subscriptionParam);
         setSocketConnected(true);
+        setLoading(false);
       }).catch((err) => {
         setError(err.message);
       });
@@ -362,6 +364,11 @@ function LobbyPage() {
         .then((res) => {
           setStateFromRoom(res);
           updateCurrentUserDetails(res.users);
+
+          // Attempt to connect the user to the socket.
+          if (currentUser && currentUser.userId) {
+            connectUserToRoom(res.roomId, currentUser.userId);
+          }
           setLoading(false);
         })
         .catch((err) => setError(err));

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -393,12 +393,12 @@ function LobbyPage() {
         });
         disconnect();
       }
-    }
 
-    // Redirect user regardless of POST request success.
-    history.replace('/game/join', {
-      error: errorHandler('You left the room.'),
-    });
+      // Redirect user regardless of POST request success.
+      history.replace('/game/join', {
+        error: errorHandler('You left the room.'),
+      });
+    }
   };
 
   // Grab the nickname variable and add the user to the lobby.

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -389,19 +389,14 @@ function LobbyPage() {
         removeUser(currentRoomId, {
           initiator: currentUser,
           userToDelete: currentUser,
-        }).catch(() => {
-          // Redirect user regardless of POST request effectiveness.
-          history.replace('/game/join', {
-            error: errorHandler('You left the room.'),
-          });
         });
       }
-    } else {
-      // Redirect user regardless of POST request effectiveness.
-      history.replace('/game/join', {
-        error: errorHandler('You left the room.'),
-      });
     }
+
+    // Redirect user regardless of POST request effectiveness.
+    history.replace('/game/join', {
+      error: errorHandler('You left the room.'),
+    });
   };
 
   // Grab the nickname variable and add the user to the lobby.

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -173,6 +173,7 @@ function LobbyPage() {
           userIncluded = true;
         }
       });
+
       // If user is no longer present in room, boot the user.
       if (!userIncluded) {
         disconnect().then(() => {
@@ -390,10 +391,11 @@ function LobbyPage() {
           initiator: currentUser,
           userToDelete: currentUser,
         });
+        disconnect();
       }
     }
 
-    // Redirect user regardless of POST request effectiveness.
+    // Redirect user regardless of POST request success.
     history.replace('/game/join', {
       error: errorHandler('You left the room.'),
     });

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -20,6 +20,7 @@ import {
   PrimaryButton,
   SmallDifficultyButton,
   InlineRefreshIcon,
+  SecondaryRedButton,
 } from '../components/core/Button';
 import Loading from '../components/core/Loading';
 import PlayerCard from '../components/card/PlayerCard';
@@ -350,9 +351,11 @@ function LobbyPage() {
         setLoading(false);
       }).catch((err) => {
         setError(err.message);
+        setLoading(false);
       });
     }).catch((err) => {
       setError(err.message);
+      setLoading(false);
     });
   }, [currentUser, conditionallyBootKickedUser]);
 
@@ -363,6 +366,8 @@ function LobbyPage() {
       getRoom(location.state.roomId)
         .then((res) => {
           setStateFromRoom(res);
+
+          // Boot the user from the room, if they are not present.
           updateCurrentUserDetails(res.users);
 
           // Attempt to connect the user to the socket.
@@ -370,8 +375,28 @@ function LobbyPage() {
             connectUserToRoom(res.roomId, currentUser.userId);
           }
           setLoading(false);
+          setError('');
         })
         .catch((err) => setError(err));
+    }
+  };
+
+  const leaveRoom = () => {
+    // eslint-disable-next-line no-alert
+    if (window.confirm('Are you sure you want to leave the room?')) {
+      if (currentUser && currentUser.userId) {
+        setLoading(true);
+        setError('');
+        removeUser(currentRoomId, {
+          initiator: currentUser,
+          userToDelete: currentUser,
+        });
+      }
+
+      // Redirect user regardless of POST request effectiveness.
+      history.replace('/game/join', {
+        error: errorHandler('You left the room.'),
+      });
     }
   };
 
@@ -456,6 +481,11 @@ function LobbyPage() {
         >
           Start Game
         </PrimaryButtonZeroLeftMargin>
+        <SecondaryRedButton
+          onClick={leaveRoom}
+        >
+          Leave Room
+        </SecondaryRedButton>
       </HeaderContainer>
 
       <FlexBareContainerLeft>

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -16,7 +16,11 @@ import {
 import { User } from '../api/User';
 import { checkLocationState, isValidRoomId } from '../util/Utility';
 import { Difficulty } from '../api/Difficulty';
-import { PrimaryButton, SmallDifficultyButton } from '../components/core/Button';
+import {
+  PrimaryButton,
+  SmallDifficultyButton,
+  InlineRefreshIcon,
+} from '../components/core/Button';
 import Loading from '../components/core/Loading';
 import PlayerCard from '../components/card/PlayerCard';
 import HostActionCard from '../components/card/HostActionCard';
@@ -442,6 +446,13 @@ function LobbyPage() {
                 ? ` (${activeUsers.length + inactiveUsers.length})`
                 : null
             }
+            <InlineRefreshIcon
+              onClick={() => {
+                alert('Hello!');
+              }}
+            >
+              refresh
+            </InlineRefreshIcon>
           </SmallHeaderTextZeroTopMargin>
           <BackgroundContainer>
             {

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -354,6 +354,20 @@ function LobbyPage() {
     });
   }, [currentUser, conditionallyBootKickedUser]);
 
+  const refreshRoomDetails = () => {
+    // Call GET endpoint to get latest room info
+    if (!loading) {
+      setLoading(true);
+      getRoom(location.state.roomId)
+        .then((res) => {
+          setStateFromRoom(res);
+          updateCurrentUserDetails(res.users);
+          setLoading(false);
+        })
+        .catch((err) => setError(err));
+    }
+  };
+
   // Grab the nickname variable and add the user to the lobby.
   useEffect(() => {
     // Grab the user and room information; otherwise, redirect to the join page
@@ -447,9 +461,7 @@ function LobbyPage() {
                 : null
             }
             <InlineRefreshIcon
-              onClick={() => {
-                alert('Hello!');
-              }}
+              onClick={refreshRoomDetails}
             >
               refresh
             </InlineRefreshIcon>

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -348,6 +348,7 @@ function LobbyPage() {
       subscribe(routes(roomId).subscribe_lobby, subscribeCallback).then((subscriptionParam) => {
         setSubscription(subscriptionParam);
         setSocketConnected(true);
+        setError('');
         setLoading(false);
       }).catch((err) => {
         setError(err.message);
@@ -374,8 +375,6 @@ function LobbyPage() {
           if (currentUser && currentUser.userId) {
             connectUserToRoom(res.roomId, currentUser.userId);
           }
-          setLoading(false);
-          setError('');
         })
         .catch((err) => setError(err));
     }
@@ -390,9 +389,14 @@ function LobbyPage() {
         removeUser(currentRoomId, {
           initiator: currentUser,
           userToDelete: currentUser,
+        }).catch(() => {
+          // Redirect user regardless of POST request effectiveness.
+          history.replace('/game/join', {
+            error: errorHandler('You left the room.'),
+          });
         });
       }
-
+    } else {
       // Redirect user regardless of POST request effectiveness.
       history.replace('/game/join', {
         error: errorHandler('You left the room.'),

--- a/src/main/java/com/rocketden/main/controller/v1/RoomController.java
+++ b/src/main/java/com/rocketden/main/controller/v1/RoomController.java
@@ -53,7 +53,7 @@ public class RoomController extends BaseRestController {
     @PutMapping("/rooms/{roomId}/host")
     public ResponseEntity<RoomDto> updateRoomHost(@PathVariable String roomId,
                                                   @RequestBody UpdateHostRequest request) {
-        return new ResponseEntity<>(service.updateRoomHost(roomId, request), HttpStatus.OK);
+        return new ResponseEntity<>(service.updateRoomHost(roomId, request, false), HttpStatus.OK);
     }
 
     @PutMapping("/rooms/{roomId}/settings")

--- a/src/main/java/com/rocketden/main/controller/v1/RoomController.java
+++ b/src/main/java/com/rocketden/main/controller/v1/RoomController.java
@@ -47,7 +47,7 @@ public class RoomController extends BaseRestController {
 
     @DeleteMapping("/rooms/{roomId}")
     public ResponseEntity<RoomDto> deleteRoom(@PathVariable String roomId, @RequestBody DeleteRoomRequest request) {
-        return new ResponseEntity<>(service.deleteRoom(roomId, request), HttpStatus.CREATED);
+        return new ResponseEntity<>(service.deleteRoom(roomId, request), HttpStatus.OK);
     }
 
     @DeleteMapping("/rooms/{roomId}/users")

--- a/src/main/java/com/rocketden/main/controller/v1/RoomController.java
+++ b/src/main/java/com/rocketden/main/controller/v1/RoomController.java
@@ -1,6 +1,7 @@
 package com.rocketden.main.controller.v1;
 
 import com.rocketden.main.dto.room.CreateRoomRequest;
+import com.rocketden.main.dto.room.DeleteRoomRequest;
 import com.rocketden.main.dto.room.JoinRoomRequest;
 import com.rocketden.main.dto.room.RoomDto;
 import com.rocketden.main.dto.room.UpdateHostRequest;
@@ -42,6 +43,11 @@ public class RoomController extends BaseRestController {
     @PostMapping("/rooms")
     public ResponseEntity<RoomDto> createRoom(@RequestBody CreateRoomRequest request) {
         return new ResponseEntity<>(service.createRoom(request), HttpStatus.CREATED);
+    }
+
+    @DeleteMapping("/rooms/{roomId}")
+    public ResponseEntity<RoomDto> deleteRoom(@PathVariable String roomId, @RequestBody DeleteRoomRequest request) {
+        return new ResponseEntity<>(service.deleteRoom(roomId, request), HttpStatus.CREATED);
     }
 
     @DeleteMapping("/rooms/{roomId}/users")

--- a/src/main/java/com/rocketden/main/dto/room/DeleteRoomRequest.java
+++ b/src/main/java/com/rocketden/main/dto/room/DeleteRoomRequest.java
@@ -1,0 +1,12 @@
+package com.rocketden.main.dto.room;
+
+import com.rocketden.main.dto.user.UserDto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DeleteRoomRequest {
+    private UserDto host;
+}

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -137,7 +137,9 @@ public class RoomService {
         }
 
         // Assign new host if user being kicked is host
-        conditionallyUpdateRoomHost(room, userToDelete);
+        if (room.getHost().equals(userToDelete)) {
+            return conditionallyUpdateRoomHost(room, userToDelete, true);
+        }
 
         room.removeUser(userToDelete);
         repository.save(room);
@@ -147,7 +149,7 @@ public class RoomService {
         return roomDto;
     }
 
-    public RoomDto updateRoomHost(String roomId, UpdateHostRequest request) {
+    public RoomDto updateRoomHost(String roomId, UpdateHostRequest request, boolean deleteOldHost) {
         Room room = repository.findRoomByRoomId(roomId);
 
         // Return error if room could not be found
@@ -178,6 +180,11 @@ public class RoomService {
 
         // Change the host to the new user
         room.setHost(newHost);
+        
+        // Remove the old host and initiator.
+        if (deleteOldHost) {
+            room.removeUser(initiator);
+        }
         repository.save(room);
 
         RoomDto roomDto = RoomMapper.toDto(room);
@@ -186,7 +193,7 @@ public class RoomService {
     }
 
     // This function randomly assigns a new host in the room
-    public RoomDto conditionallyUpdateRoomHost(Room room, User user) {
+    public RoomDto conditionallyUpdateRoomHost(Room room, User user, boolean deleteOldHost) {
         // If the disconnected user is the host and another active user is present, reassign the host for the room.
         if (room.getHost().equals(user)) {
             UpdateHostRequest request = new UpdateHostRequest();
@@ -202,7 +209,7 @@ public class RoomService {
 
             // Determine whether an active non-host user was found, and if so, send an update room host request.
             if (request.getNewHost() != null) {
-                return updateRoomHost(room.getRoomId(), request);
+                return updateRoomHost(room.getRoomId(), request, deleteOldHost);
             }
         }
         // If conditions fail to match, just return the room as it is

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -2,6 +2,7 @@ package com.rocketden.main.service;
 
 import com.rocketden.main.dao.RoomRepository;
 import com.rocketden.main.dto.room.CreateRoomRequest;
+import com.rocketden.main.dto.room.DeleteRoomRequest;
 import com.rocketden.main.dto.room.JoinRoomRequest;
 import com.rocketden.main.dto.room.RoomDto;
 import com.rocketden.main.dto.room.RoomMapper;
@@ -100,6 +101,18 @@ public class RoomService {
         room.setHost(host);
         room.addUser(host);
         repository.save(room);
+
+        return RoomMapper.toDto(room);
+    }
+
+    public RoomDto deleteRoom(String roomId, DeleteRoomRequest request) {
+        Room room = repository.findRoomByRoomId(roomId);
+        User host = UserMapper.toEntity(request.getHost());
+
+        // Do not create room if provided user is not the host.
+        if (!room.getHost().equals(host)) {
+            throw new ApiException(RoomError.INVALID_PERMISSIONS);
+        }
 
         return RoomMapper.toDto(room);
     }

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -114,7 +114,11 @@ public class RoomService {
             throw new ApiException(RoomError.INVALID_PERMISSIONS);
         }
 
-        return RoomMapper.toDto(room);
+        RoomDto roomDto = RoomMapper.toDto(room);
+
+        // Delete the room and all users within as well.
+        repository.delete(room);
+        return roomDto;
     }
 
     public RoomDto getRoom(String roomId) {
@@ -151,6 +155,14 @@ public class RoomService {
 
         // Assign new host if user being kicked is host
         if (room.getHost().equals(userToDelete)) {
+
+            // If the host is the last user, delete the room and return info.
+            if (room.getUsers().size() == 1) {
+                DeleteRoomRequest deleteRoomRequest = new DeleteRoomRequest();
+                deleteRoomRequest.setHost(request.getUserToDelete());
+                return deleteRoom(roomId, deleteRoomRequest);
+            }
+
             return conditionallyUpdateRoomHost(room, userToDelete, true);
         }
 

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -126,8 +126,8 @@ public class RoomService {
         User initiator = UserMapper.toEntity(request.getInitiator());
         User userToDelete = UserMapper.toEntity(request.getUserToDelete());
 
-        // Return error if the initiator is not the host
-        if (!room.getHost().equals(initiator)) {
+        // Return error if the initiator is not the host or user themselves
+        if (!room.getHost().equals(initiator) && !initiator.equals(userToDelete)) {
             throw new ApiException(RoomError.INVALID_PERMISSIONS);
         }
 

--- a/src/main/java/com/rocketden/main/socket/WebSocketConnectionEvents.java
+++ b/src/main/java/com/rocketden/main/socket/WebSocketConnectionEvents.java
@@ -111,7 +111,7 @@ public class WebSocketConnectionEvents {
 
             // Get room, conditionally update the host, and send socket update.
             Room room = user.getRoom();
-            RoomDto roomDto = roomService.conditionallyUpdateRoomHost(room, user);
+            RoomDto roomDto = roomService.conditionallyUpdateRoomHost(room, user, false);
             socketService.sendSocketUpdate(roomDto);
 
             // If a game exists, update the room info for that game

--- a/src/test/java/com/rocketden/main/api/RoomTests.java
+++ b/src/test/java/com/rocketden/main/api/RoomTests.java
@@ -57,8 +57,10 @@ public class RoomTests {
     // Predefine user and room attributes.
     private static final String NICKNAME = "rocket";
     private static final String NICKNAME_2 = "rocketrocket";
+    private static final String NICKNAME_3 = "rocketandrocket";
     private static final String USER_ID = "012345";
     private static final String USER_ID_2 = "678910";
+    private static final String USER_ID_3 = "024681";
     private static final String ROOM_ID = "012345";
     private static final long DURATION = 600;
 
@@ -497,7 +499,7 @@ public class RoomTests {
     }
 
     @Test
-    public void removeUserSuccess() throws Exception {
+    public void removeUserSuccessHostInitiator() throws Exception {
         UserDto host = new UserDto();
         host.setNickname(NICKNAME);
         host.setUserId(USER_ID);
@@ -510,6 +512,35 @@ public class RoomTests {
 
         RemoveUserRequest request = new RemoveUserRequest();
         request.setInitiator(host);
+        request.setUserToDelete(user);
+
+        MvcResult result = this.mockMvc.perform(delete(String.format(REMOVE_USER, room.getRoomId()))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(UtilityTestMethods.convertObjectToJsonString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String jsonResponse = result.getResponse().getContentAsString();
+        room = UtilityTestMethods.toObject(jsonResponse, RoomDto.class);
+
+        assertEquals(1, room.getUsers().size());
+        assertFalse(room.getUsers().contains(user));
+    }
+
+    @Test
+    public void removeUserSuccessSelfInitiator() throws Exception {
+        UserDto host = new UserDto();
+        host.setNickname(NICKNAME);
+        host.setUserId(USER_ID);
+
+        UserDto user = new UserDto();
+        user.setNickname(NICKNAME_2);
+        user.setUserId(USER_ID_2);
+
+        RoomDto room = RoomTestMethods.setUpRoomWithTwoUsers(this.mockMvc, host, user);
+
+        RemoveUserRequest request = new RemoveUserRequest();
+        request.setInitiator(user);
         request.setUserToDelete(user);
 
         MvcResult result = this.mockMvc.perform(delete(String.format(REMOVE_USER, room.getRoomId()))
@@ -564,10 +595,14 @@ public class RoomTests {
         user.setNickname(NICKNAME_2);
         user.setUserId(USER_ID_2);
 
+        UserDto user2 = new UserDto();
+        user2.setNickname(NICKNAME_3);
+        user2.setUserId(USER_ID_3);
+
         RoomDto room = RoomTestMethods.setUpRoomWithTwoUsers(this.mockMvc, host, user);
 
         RemoveUserRequest request = new RemoveUserRequest();
-        request.setInitiator(user);
+        request.setInitiator(user2);
         request.setUserToDelete(user);
 
         ApiError ERROR = RoomError.INVALID_PERMISSIONS;

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -2,6 +2,7 @@ package com.rocketden.main.service;
 
 import com.rocketden.main.dao.RoomRepository;
 import com.rocketden.main.dto.room.CreateRoomRequest;
+import com.rocketden.main.dto.room.DeleteRoomRequest;
 import com.rocketden.main.dto.room.JoinRoomRequest;
 import com.rocketden.main.dto.room.RoomDto;
 import com.rocketden.main.dto.room.UpdateHostRequest;
@@ -28,6 +29,7 @@ import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -642,5 +644,56 @@ public class RoomServiceTests {
         assertEquals(user3, room.getHost());
 
         verify(repository).save(room);
+    }
+
+    @Test
+    public void deleteRoomSuccess() {
+        User host = new User();
+        host.setUserId(USER_ID);
+        host.setSessionId(SESSION_ID);
+
+        User user = new User();
+        user.setUserId(USER_ID_2);
+        user.setSessionId(SESSION_ID_2);
+
+        Room room = new Room();
+        room.setRoomId(ROOM_ID);
+        room.setHost(host);
+        room.addUser(host);
+        room.addUser(user);
+
+        Mockito.doReturn(room).when(repository).findRoomByRoomId(eq(ROOM_ID));
+
+        DeleteRoomRequest deleteRoomRequest = new DeleteRoomRequest();
+        deleteRoomRequest.setHost(UserMapper.toDto(host));
+        roomService.deleteRoom(ROOM_ID, deleteRoomRequest);
+        verify(repository).delete(eq(room));
+    }
+
+    @Test
+    public void deleteRoomBadHost() {
+        User host = new User();
+        host.setUserId(USER_ID);
+        host.setSessionId(SESSION_ID);
+
+        User user = new User();
+        user.setUserId(USER_ID_2);
+        user.setSessionId(SESSION_ID_2);
+
+        Room room = new Room();
+        room.setRoomId(ROOM_ID);
+        room.setHost(host);
+        room.addUser(host);
+        room.addUser(user);
+
+        Mockito.doReturn(room).when(repository).findRoomByRoomId(eq(ROOM_ID));
+
+        DeleteRoomRequest deleteRoomRequest = new DeleteRoomRequest();
+        deleteRoomRequest.setHost(UserMapper.toDto(user));
+
+        ApiException exception = assertThrows(ApiException.class, () ->
+                roomService.deleteRoom(ROOM_ID, deleteRoomRequest));
+        assertEquals(RoomError.INVALID_PERMISSIONS, exception.getError());
+        assertNotNull(roomService.getRoom(ROOM_ID));
     }
 }

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -444,7 +444,7 @@ public class RoomServiceTests {
     }
 
     @Test
-    public void removeUserSuccess() {
+    public void removeUserSuccessHostInitiator() {
         Room room = new Room();
         room.setRoomId(ROOM_ID);
 
@@ -464,6 +464,35 @@ public class RoomServiceTests {
 
         RemoveUserRequest request = new RemoveUserRequest();
         request.setInitiator(UserMapper.toDto(host));
+        request.setUserToDelete(UserMapper.toDto(user));
+        RoomDto response = roomService.removeUser(ROOM_ID, request);
+
+        verify(socketService).sendSocketUpdate(eq(response));
+        assertEquals(1, response.getUsers().size());
+        assertFalse(response.getUsers().contains(UserMapper.toDto(user)));
+    }
+
+    @Test
+    public void removeUserSuccessSelfInitiator() {
+        Room room = new Room();
+        room.setRoomId(ROOM_ID);
+
+        User host = new User();
+        host.setNickname(NICKNAME);
+        host.setUserId(USER_ID);
+
+        room.setHost(host);
+        room.addUser(host);
+
+        User user = new User();
+        user.setNickname(NICKNAME_2);
+        user.setUserId(USER_ID_2);
+        room.addUser(user);
+
+        Mockito.doReturn(room).when(repository).findRoomByRoomId(eq(ROOM_ID));
+
+        RemoveUserRequest request = new RemoveUserRequest();
+        request.setInitiator(UserMapper.toDto(user));
         request.setUserToDelete(UserMapper.toDto(user));
         RoomDto response = roomService.removeUser(ROOM_ID, request);
 
@@ -547,11 +576,16 @@ public class RoomServiceTests {
         user.setUserId(USER_ID_2);
         room.addUser(user);
 
+        User user2 = new User();
+        user2.setNickname(NICKNAME_2);
+        user2.setUserId(USER_ID_3);
+        room.addUser(user2);
+
         Mockito.doReturn(room).when(repository).findRoomByRoomId(eq(ROOM_ID));
 
         RemoveUserRequest request = new RemoveUserRequest();
         request.setInitiator(UserMapper.toDto(user));
-        request.setUserToDelete(UserMapper.toDto(user));
+        request.setUserToDelete(UserMapper.toDto(user2));
 
         ApiException exception = assertThrows(ApiException.class, () ->
                 roomService.removeUser(ROOM_ID, request));

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -220,7 +220,7 @@ public class RoomServiceTests {
         request.setInitiator(UserMapper.toDto(host));
         request.setNewHost(UserMapper.toDto(user));
 
-        RoomDto response = roomService.updateRoomHost(room.getRoomId(), request);
+        RoomDto response = roomService.updateRoomHost(room.getRoomId(), request, false);
 
         verify(socketService).sendSocketUpdate(eq(response));
         assertEquals(user, UserMapper.toEntity(response.getHost()));
@@ -251,7 +251,7 @@ public class RoomServiceTests {
         invalidPermRequest.setNewHost(UserMapper.toDto(host));
 
         ApiException exception = assertThrows(ApiException.class, () ->
-                roomService.updateRoomHost(ROOM_ID, invalidPermRequest));
+                roomService.updateRoomHost(ROOM_ID, invalidPermRequest, false));
         assertEquals(RoomError.INVALID_PERMISSIONS, exception.getError());
 
         // Nonexistent room
@@ -260,7 +260,7 @@ public class RoomServiceTests {
         noRoomRequest.setNewHost(UserMapper.toDto(user));
 
         exception = assertThrows(ApiException.class, () ->
-                roomService.updateRoomHost("999999", noRoomRequest));
+                roomService.updateRoomHost("999999", noRoomRequest, false));
         assertEquals(RoomError.NOT_FOUND, exception.getError());
 
         // Nonexistent new host
@@ -272,7 +272,7 @@ public class RoomServiceTests {
         noUserRequest.setNewHost(nonExistentUser);
 
         exception = assertThrows(ApiException.class, () ->
-                roomService.updateRoomHost(ROOM_ID, noUserRequest));
+                roomService.updateRoomHost(ROOM_ID, noUserRequest, false));
         assertEquals(UserError.NOT_FOUND, exception.getError());
 
         // New host inactive
@@ -282,7 +282,7 @@ public class RoomServiceTests {
         inactiveUserRequest.setNewHost(UserMapper.toDto(user));
 
         exception = assertThrows(ApiException.class, () ->
-                roomService.updateRoomHost(ROOM_ID, inactiveUserRequest));
+                roomService.updateRoomHost(ROOM_ID, inactiveUserRequest, false));
         assertEquals(RoomError.INACTIVE_USER, exception.getError());
     }
 

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -632,13 +632,13 @@ public class RoomServiceTests {
         room.addUser(user3);
 
         // Passing in a non-host user has no effect on the room
-        roomService.conditionallyUpdateRoomHost(room, user2);
+        roomService.conditionallyUpdateRoomHost(room, user2, false);
         assertEquals(user1, room.getHost());
 
         Mockito.doReturn(room).when(repository).findRoomByRoomId(eq(room.getRoomId()));
 
         // Passing in the host will assign the first active user to be the new host
-        roomService.conditionallyUpdateRoomHost(room, user1);
+        roomService.conditionallyUpdateRoomHost(room, user1, false);
         assertEquals(user3, room.getHost());
 
         verify(repository).save(room);


### PR DESCRIPTION
### List of Changes:
- Add a "refresh" button to the room page that fetches the latest room details through the `getRoom` REST request and attempts connecting to the socket again, if not already connected.
- Add a "Leave Room" button that anybody can use, and deletes the room if the last person leaves.
- Add a "Delete Room" endpoint and add the relevant tests.
- Slightly resize the landing page "Create a room" button.

### Notes:
- The "Delete Room" request also automatically deletes all of the users that were in that room, I believe due to cascading effects. This works well for now, as we don't want to keep anonymous users in the database, but will not be the desired behavior once / if we implement registered users (online, student, or teacher).
- I'm not certain how useful the refresh button is - it doesn't seem to provide any updates for the "active / inactive" state of users (there should be more troubleshooting on why exactly this is), but can update some other contents. It may be useful largely as a [Placebo Button](https://en.wikipedia.org/wiki/Placebo_button) (with the distinguishing factor that this button _can_ be helpful, though potentially only in select cases).
- Potentially in the future, the refresh button could also ping all of the users to confirm their "active / inactive" socket connection state. (Related to this, it may be important for reliability to set up "ping pong" socket confirmations.)
- When the user clicks "Leave Room" and accepts the window confirmation, they are immediately disconnected without waiting for the actual "kickUser" and "disconnect" callbacks to return; I did this because in my mind, regardless of whether those actions are successful, the user should leave the room. However, in the case that these functions do fail, this may create unexpected behaviors.

### Screencast and Images:

[Screencast of Lobby Page Refresh and Leave Room Buttons](https://www.loom.com/share/91075b8d52fa40c785f4387a0e352313)

_Note:_ I meant to demonstrate the "refresh" functionality on the above screencast too, but forgot - you can test this by directly deleting a user in the database (so no updates will be immediately rendered on the frontend), then clicking refresh to show that information is received and updated. I have confirmed it also attempts to connect to the socket if not already done so, though this feature in particular may be more flaky.

**Add Refresh and Leave Room Buttons to the Lobby Page**
<img width="1274" alt="Add Refresh and Leave Room Buttons to the Lobby Page" src="https://user-images.githubusercontent.com/7987279/111863105-a37b8880-8916-11eb-9ab7-ee9ae0e183d1.png">

**Updated Lobby Page with Disabled Buttons**
<img width="1280" alt="Updated Lobby Page with Disabled Buttons" src="https://user-images.githubusercontent.com/7987279/111863277-cd817a80-8917-11eb-9dd6-8e27bafadcba.png">

**Updated Button Size on Landing Page**
<img width="1280" alt="Updated Button on Landing Page" src="https://user-images.githubusercontent.com/7987279/111863120-bd1cd000-8916-11eb-94e0-1f79feeac73f.png">
