### PR TITLE
adding backend and tests for a room limit for users

### DIFF
--- a/src/main/java/com/rocketden/main/exception/RoomError.java
+++ b/src/main/java/com/rocketden/main/exception/RoomError.java
@@ -14,7 +14,8 @@ public enum RoomError implements ApiError {
     NO_HOST(HttpStatus.BAD_REQUEST, "There is no host provided."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "A room could not be found with the given id."),
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "A user with the nickname provided has already joined the room."),
-    ALREADY_ACTIVE(HttpStatus.FORBIDDEN, "Cannot join a room that is already active.");
+    ALREADY_ACTIVE(HttpStatus.FORBIDDEN, "Cannot join a room that is already active."),
+    ALREADY_FULL(HttpStatus.FORBIDDEN, "Cannot join a room that is already full.");
 
     private final HttpStatus status;
     private final ApiErrorResponse response;

--- a/src/main/java/com/rocketden/main/model/Room.java
+++ b/src/main/java/com/rocketden/main/model/Room.java
@@ -58,6 +58,8 @@ public class Room {
 
     private Integer numProblems = 1;
 
+    private Integer maxSize = 4;
+
     public void addUser(User user) {
         users.add(user);
         user.setRoom(this);
@@ -119,5 +121,15 @@ public class Room {
             }
         }
         return false;
+    }
+
+
+    /**
+     * Determine whether the room has already reached the maximum capacity.
+     * @return true if the number of users in the room is equal to or greater
+     * than the maximum size of the room
+     */
+    public boolean isFull() {
+        return users.size() >= maxSize;
     }
 }

--- a/src/main/java/com/rocketden/main/service/RoomService.java
+++ b/src/main/java/com/rocketden/main/service/RoomService.java
@@ -47,6 +47,10 @@ public class RoomService {
             throw new ApiException(RoomError.NOT_FOUND);
         }
 
+        if (room.isFull()) {
+            throw new ApiException(RoomError.ALREADY_FULL);
+        }
+
         // Get the user who initialized the request.
         User user = UserMapper.toEntity(request.getUser());
 

--- a/src/test/java/com/rocketden/main/service/RoomServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/RoomServiceTests.java
@@ -57,6 +57,8 @@ public class RoomServiceTests {
     private static final String NICKNAME = "rocket";
     private static final String NICKNAME_2 = "rocketrocket";
     private static final String NICKNAME_3 = "rocketandrocket";
+    private static final String NICKNAME_4 = "rocketrocketrocket";
+    private static final String NICKNAME_5 = "rocketandrocketrocket";
     private static final String SESSION_ID = "abcdef";
     private static final String SESSION_ID_2 = "ghijkl";
     private static final String ROOM_ID = "012345";
@@ -167,6 +169,44 @@ public class RoomServiceTests {
         verify(repository).findRoomByRoomId(ROOM_ID);
         assertEquals(RoomError.DUPLICATE_USERNAME, exception.getError());
     }
+
+    @Test
+    public void joinFullRoomFailure() {
+        /**
+         * Verify join room request fails when the room is already full
+         * Define five users, and add to the room
+         */
+        User firstUser = new User();
+        firstUser.setNickname(NICKNAME);
+        User secondUser = new User();
+        secondUser.setNickname(NICKNAME_2);
+        User thirdUser = new User();
+        thirdUser.setNickname(NICKNAME_3);
+        User fourthUser = new User();
+        fourthUser.setNickname(NICKNAME_4);
+        UserDto fifthUser = new UserDto();
+        fifthUser.setNickname(NICKNAME_5);
+
+        JoinRoomRequest request = new JoinRoomRequest();
+        request.setUser(fifthUser);
+
+        Room room = new Room();
+        room.setRoomId(ROOM_ID);
+        room.setHost(firstUser);
+        room.addUser(firstUser);
+        
+        room.addUser(secondUser);
+        room.addUser(thirdUser);
+        room.addUser(fourthUser);
+
+        // Mock repository to return room when called
+        Mockito.doReturn(room).when(repository).findRoomByRoomId(eq(ROOM_ID));
+        ApiException exception = assertThrows(ApiException.class, () -> roomService.joinRoom(ROOM_ID, request));
+
+        verify(repository).findRoomByRoomId(ROOM_ID);
+        assertEquals(RoomError.ALREADY_FULL, exception.getError());
+    }
+
 
     @Test
     public void getRoomSuccess() {


### PR DESCRIPTION
### List of Changes:

- A fifth user attempting to join a room will be unable to and given the message "Cannot join a room that is already full."

### Notes:

- isFull() depends on the users list being correct, with all the users
- Currently the room limit is hardcoded at four
- The exception for an already full room is HttpStatus.FORBIDDEN. I'm not sure that's the correct one.
- The JUnit tests are dependent on the room limit being set to 4.

### Screencast and Images:

![Cap62](https://user-images.githubusercontent.com/37048580/112076031-dc924380-8b36-11eb-88ed-2a414e80e22b.PNG)
![Cap61](https://user-images.githubusercontent.com/37048580/112076056-e4ea7e80-8b36-11eb-852f-597e5b93c12b.PNG)
