### PR TITLE
Update results page design with podium

### DIFF
--- a/frontend/src/api/Language.ts
+++ b/frontend/src/api/Language.ts
@@ -11,8 +11,19 @@ enum Language {
   // Bash = 'BASH',
 }
 
+// 'PYTHON' to Language.Python
+// value as Language
+
+// Python -> Language.Python
 export const fromString = (key: string): Language => Language[key as keyof typeof Language];
 
+// Language.Python -> Python
+export const displayNameFromLanguage = (language: Language) => {
+  const keys = Object.keys(Language).filter((key) => fromString(key) === language);
+  return keys.length > 0 ? keys[0] : '';
+};
+
+// Language.Python to python
 export const languageToEditorLanguage = (key: Language): string => {
   // Swift, Rust, and Bash do not have corresponding editor languages.
   switch (key) {

--- a/frontend/src/components/card/LeaderboardCard.tsx
+++ b/frontend/src/components/card/LeaderboardCard.tsx
@@ -83,7 +83,7 @@ function LeaderboardCard(props: LeaderboardCardProps) {
     if (latest && (!bestSubmission || latest.numCorrect > bestSubmission.numCorrect)) {
       setBestSubmission(latest);
     }
-  }, [player, setBestSubmission]);
+  }, [player, bestSubmission, setBestSubmission]);
 
   const getScoreDisplay = () => {
     if (!bestSubmission) {

--- a/frontend/src/components/card/LeaderboardCard.tsx
+++ b/frontend/src/components/card/LeaderboardCard.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { Player } from '../../api/Game';
+import { Player, Submission } from '../../api/Game';
 import { LowMarginText, SmallText } from '../core/Text';
 import PlayerIcon from './PlayerIcon';
 import { Color } from '../../api/Color';
@@ -74,32 +74,38 @@ function LeaderboardCard(props: LeaderboardCardProps) {
   } = props;
 
   const [showHover, setShowHover] = useState(false);
+  const [bestSubmission, setBestSubmission] = useState<Submission | null>(null);
+
+  useEffect(() => {
+    const latest = player.submissions.slice(-1)[0];
+
+    // Set latest as best submission if it's the first submission or scores higher
+    if (latest && (!bestSubmission || latest.numCorrect > bestSubmission.numCorrect)) {
+      setBestSubmission(latest);
+    }
+  }, [player, setBestSubmission]);
 
   const getScoreDisplay = () => {
-    const latestSubmission = player.submissions.slice(-1)[0];
-    if (!latestSubmission) {
+    if (!bestSubmission) {
       return '0';
     }
-    return `${latestSubmission.numCorrect}/${latestSubmission.numTestCases}`;
+    return `${bestSubmission.numCorrect}/${bestSubmission.numTestCases}`;
   };
 
   const getScorePercentage = () => {
-    const latestSubmission = player.submissions.slice(-1)[0];
-    if (!latestSubmission) {
+    if (!bestSubmission) {
       return '';
     }
-
-    return ` ${Math.round((latestSubmission.numCorrect / latestSubmission.numTestCases) * 100)}%`;
+    return ` ${Math.round((bestSubmission.numCorrect / bestSubmission.numTestCases) * 100)}%`;
   };
 
   const getSubmissionTime = () => {
-    const latestSubmission = player.submissions.slice(-1)[0];
-    if (!latestSubmission) {
+    if (!bestSubmission) {
       return 'Never';
     }
 
     const currentTime = new Date().getTime();
-    const diffMilliseconds = currentTime - new Date(latestSubmission.startTime).getTime();
+    const diffMilliseconds = currentTime - new Date(bestSubmission.startTime).getTime();
     const diffMinutes = Math.floor(diffMilliseconds / (60 * 1000));
     return `${diffMinutes}m ago`;
   };

--- a/frontend/src/components/config/App.tsx
+++ b/frontend/src/components/config/App.tsx
@@ -25,7 +25,7 @@ function App() {
       <CustomRoute path="/game/join" component={JoinGamePage} layout={MainLayout} exact />
       <CustomRoute path="/game/create" component={CreateGamePage} layout={MainLayout} exact />
       <CustomRoute path="/game/lobby" component={LobbyPage} layout={MinimalLayout} exact />
-      <CustomRoute path="/game/results" component={GameResultsPage} layout={MainLayout} exact />
+      <CustomRoute path="/game/results" component={GameResultsPage} layout={MinimalLayout} exact />
       <CustomRoute path="/problems/all" component={AllProblemsPage} layout={MinimalLayout} exact />
       <CustomRoute path="/problem/create" component={CreateProblemPage} layout={MinimalLayout} exact />
       <CustomRoute path="/problem/:id" component={ProblemPage} layout={MinimalLayout} exact />

--- a/frontend/src/components/config/Theme.tsx
+++ b/frontend/src/components/config/Theme.tsx
@@ -27,6 +27,8 @@ export const ThemeConfig: any = {
       blue: 'linear-gradient(207.68deg, #133ED7 10.68%, #B7D4FF 91.96%)',
       pink: 'linear-gradient(207.68deg, #F25AFF 10.68%, #F5DAFF 91.96%)',
       yellow: 'linear-gradient(207.68deg, #FFC700 10.68%, #FFFDC1 91.96%)',
+      silver: 'linear-gradient(228.67deg, #C3C3C3 15.07%, #FAFAFA 89.32%)',
+      bronze: 'linear-gradient(228.67deg, #D2AB46 15.07%, #FDEEC6 89.32%)',
       purple: 'linear-gradient(207.68deg, #9845EC 21.37%, #D9B4FF 102.65%)',
       gray: 'linear-gradient(228.67deg, #555555 15.07%, #C8C8C8 89.32%)',
     },

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -37,6 +37,10 @@ export const NoMarginSubtitleText = styled.p`
   margin: 0;
 `;
 
+export const SmallerMediumText = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.mediumLarge};
+`;
+
 export const MediumText = styled.h5`
   font-size: ${({ theme }) => theme.fontSize.xMediumLarge};
 `;

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -39,6 +39,7 @@ export const NoMarginSubtitleText = styled.p`
 
 export const SmallerMediumText = styled.p`
   font-size: ${({ theme }) => theme.fontSize.mediumLarge};
+  margin: 5px 0;
 `;
 
 export const MediumText = styled.h5`

--- a/frontend/src/components/core/Text.tsx
+++ b/frontend/src/components/core/Text.tsx
@@ -37,11 +37,6 @@ export const NoMarginSubtitleText = styled.p`
   margin: 0;
 `;
 
-export const SmallerMediumText = styled.p`
-  font-size: ${({ theme }) => theme.fontSize.mediumLarge};
-  margin: 5px 0;
-`;
-
 export const MediumText = styled.h5`
   font-size: ${({ theme }) => theme.fontSize.xMediumLarge};
 `;

--- a/frontend/src/components/special/Podium.tsx
+++ b/frontend/src/components/special/Podium.tsx
@@ -8,6 +8,7 @@ type PodiumProps = {
   place: number,
   player: Player | undefined,
   gameStartTime: string,
+  loading: boolean,
 };
 
 type MedalProps = {
@@ -31,7 +32,7 @@ const PodiumContainer = styled.div<HeightProps>`
   width: 180px;
   height: ${({ height }) => height}px;
   padding: 10px;
-  margin: 10px;
+  margin: 5px 10px;
   background: ${({ theme }) => theme.colors.white};
   border-radius: 8px;
 `;
@@ -69,7 +70,9 @@ const Medal = styled.div<MedalProps>`
 `;
 
 function Podium(props: PodiumProps) {
-  const { place, player, gameStartTime } = props;
+  const {
+    place, player, gameStartTime, loading,
+  } = props;
 
   const [bestSubmission, setBestSubmission] = useState<Submission | null>(null);
 
@@ -108,7 +111,7 @@ function Podium(props: PodiumProps) {
 
   const getScoreText = () => {
     if (!bestSubmission) {
-      return <ScoreText />;
+      return <ScoreText>{loading ? 'Scoring...' : 'Invite'}</ScoreText>;
     }
 
     const percent = Math.round((bestSubmission.numCorrect / bestSubmission.numTestCases) * 100);
@@ -154,7 +157,7 @@ function Podium(props: PodiumProps) {
   return (
     <Content>
       <div>
-        <WinnerText>{player?.user.nickname || 'Invite'}</WinnerText>
+        <WinnerText>{player?.user.nickname || ''}</WinnerText>
         <PodiumContainer height={getPodiumHeight()}>
           <Medal color={getMedalColor()} />
           {getScoreText()}

--- a/frontend/src/components/special/Podium.tsx
+++ b/frontend/src/components/special/Podium.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Player } from '../../api/Game';
+import { MediumText } from '../core/Text';
 
 type PodiumProps = {
   place: string,
@@ -8,8 +9,7 @@ type PodiumProps = {
 };
 
 type MedalProps = {
-  place: number,
-  player?: Player,
+  color: string,
 };
 
 const PodiumContainer = styled.div`
@@ -24,7 +24,7 @@ const PodiumContainer = styled.div`
 `;
 
 const Medal = styled.div<MedalProps>`
-  background: ${({ theme }) => theme.colors.gradients.yellow};
+  background: ${({ theme, color }) => theme.colors.gradients[color]};
   border-radius: 50%;
   margin: 0 auto;
   
@@ -34,11 +34,12 @@ const Medal = styled.div<MedalProps>`
 `;
 
 function Podium(props: PodiumProps) {
-  const { place } = props;
+  const { place, player } = props;
 
   return (
     <PodiumContainer>
-      <Medal />
+      <Medal color="yellow" />
+      <MediumText>temp</MediumText>
       Score
       Time
       Language

--- a/frontend/src/components/special/Podium.tsx
+++ b/frontend/src/components/special/Podium.tsx
@@ -78,12 +78,16 @@ function Podium(props: PodiumProps) {
 
   useEffect(() => {
     if (player) {
+      let newBestSubmission: Submission | null = bestSubmission;
+
       // Find best submission
       player.submissions.forEach((submission) => {
-        if (!bestSubmission || submission.numCorrect > bestSubmission.numCorrect) {
-          setBestSubmission(submission);
+        if (!newBestSubmission || submission.numCorrect > newBestSubmission.numCorrect) {
+          newBestSubmission = submission;
         }
       });
+
+      setBestSubmission(newBestSubmission);
     }
   }, [player, setBestSubmission]);
 
@@ -115,7 +119,7 @@ function Podium(props: PodiumProps) {
     }
 
     if (!bestSubmission) {
-      return <ScoreText>{loading ? 'Loading...' : 'Scored 0'}</ScoreText>;
+      return <ScoreText>Scored 0</ScoreText>;
     }
 
     const percent = Math.round((bestSubmission.numCorrect / bestSubmission.numTestCases) * 100);
@@ -140,7 +144,7 @@ function Podium(props: PodiumProps) {
     return (
       <SmallerText>
         in
-        <b>{` ${diffMinutes} minutes`}</b>
+        <b>{` ${diffMinutes} minute${diffMinutes === 1 ? '' : 's'}`}</b>
       </SmallerText>
     );
   };

--- a/frontend/src/components/special/Podium.tsx
+++ b/frontend/src/components/special/Podium.tsx
@@ -4,6 +4,8 @@ import { Player, Submission } from '../../api/Game';
 import { SmallerMediumText, MediumText } from '../core/Text';
 import Language, { displayNameFromLanguage } from '../../api/Language';
 
+const totalPodiumHeight = 350;
+
 type PodiumProps = {
   place: number,
   player: Player | undefined,
@@ -14,16 +16,31 @@ type MedalProps = {
   color: string,
 };
 
-const PodiumContainer = styled.div`
+type HeightProps = {
+  height: number,
+};
+
+const Content = styled.div<HeightProps>`
+  padding-top: ${({ height }) => (totalPodiumHeight - height) * 2}px;
+  display: inline-block;
+  justify-content: space-between;
+`;
+
+const PodiumContainer = styled.div<HeightProps>`
   position: relative;
   display: inline-block;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
-  width: 220px;
-  height: 340px;
+  width: 200px;
+  height: ${({ height }) => height}px;
   padding: 10px;
   margin: 10px;
   background: ${({ theme }) => theme.colors.white};
   border-radius: 8px;
+`;
+
+const WinnerText = styled(MediumText)`
+  font-weight: bold;
+  margin: 0;
 `;
 
 const ScoreText = styled(MediumText)`
@@ -65,9 +82,31 @@ function Podium(props: PodiumProps) {
     }
   }, [player, setBestSubmission]);
 
+  const getMedalColor = () => {
+    switch (place) {
+      case 1:
+        return 'yellow';
+      case 2:
+        return 'silver';
+      default:
+        return 'bronze';
+    }
+  };
+
+  const getPodiumHeight = () => {
+    switch (place) {
+      case 1:
+        return 320;
+      case 2:
+        return 280;
+      default:
+        return 240;
+    }
+  };
+
   const getScoreText = () => {
     if (!bestSubmission) {
-      return <p />;
+      return <ScoreText>N/A</ScoreText>;
     }
 
     const percent = Math.round((bestSubmission.numCorrect / bestSubmission.numTestCases) * 100);
@@ -81,7 +120,7 @@ function Podium(props: PodiumProps) {
 
   const getTimeText = () => {
     if (!bestSubmission) {
-      return <p />;
+      return <SmallerMediumText>N/A</SmallerMediumText>;
     }
 
     // Calculate time from start of game till best submission
@@ -99,12 +138,9 @@ function Podium(props: PodiumProps) {
 
   const getLanguageText = () => {
     if (!bestSubmission) {
-      return <p />;
+      return <SmallerMediumText>Language: N/A</SmallerMediumText>;
     }
-    // console.log(bestSubmission);
-    // console.log(fromString(bestSubmission.language));
-    // console.log(bestSubmission.language as Language);
-    // debugger;
+
     return (
       <SmallerMediumText>
         Language:
@@ -114,15 +150,20 @@ function Podium(props: PodiumProps) {
   };
 
   return (
-    <PodiumContainer>
-      <Medal color="yellow" />
-      {getScoreText()}
-      {getTimeText()}
+    <Content height={getPodiumHeight()}>
+      <div>
+        <WinnerText>{player?.user.nickname || 'Invite'}</WinnerText>
+        <PodiumContainer height={getPodiumHeight()}>
+          <Medal color={getMedalColor()} />
+          {getScoreText()}
+          {getTimeText()}
 
-      <BottomContent>
-        {getLanguageText()}
-      </BottomContent>
-    </PodiumContainer>
+          <BottomContent>
+            {getLanguageText()}
+          </BottomContent>
+        </PodiumContainer>
+      </div>
+    </Content>
   );
 }
 

--- a/frontend/src/components/special/Podium.tsx
+++ b/frontend/src/components/special/Podium.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Player, Submission } from '../../api/Game';
-import { MediumText, SmallerMediumText } from '../core/Text';
-import Language from '../../api/Language';
+import { SmallerMediumText, MediumText } from '../core/Text';
+import Language, { displayNameFromLanguage } from '../../api/Language';
 
 type PodiumProps = {
   place: number,
@@ -15,26 +15,34 @@ type MedalProps = {
 };
 
 const PodiumContainer = styled.div`
-  display: block;
+  position: relative;
+  display: inline-block;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
-  width: 300px;
-  height: 500px;
+  width: 220px;
+  height: 340px;
   padding: 10px;
-  margin: 20px;
+  margin: 10px;
   background: ${({ theme }) => theme.colors.white};
   border-radius: 8px;
+`;
+
+const ScoreText = styled(MediumText)`
+  font-weight: normal;
+  margin: 0;
 `;
 
 const BottomContent = styled.div`
   position: absolute;
   bottom: 5px;
-  left: 50%;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
 `;
 
 const Medal = styled.div<MedalProps>`
   background: ${({ theme, color }) => theme.colors.gradients[color]};
   border-radius: 50%;
-  margin: 0 auto;
+  margin: 15px auto;
   
   height: 50px;
   width: 50px;  
@@ -59,16 +67,21 @@ function Podium(props: PodiumProps) {
 
   const getScoreText = () => {
     if (!bestSubmission) {
-      return '';
+      return <p />;
     }
 
     const percent = Math.round((bestSubmission.numCorrect / bestSubmission.numTestCases) * 100);
-    return `Scored <b>${percent}%</b>`;
+    return (
+      <ScoreText>
+        Scored
+        <b>{` ${percent}%`}</b>
+      </ScoreText>
+    );
   };
 
   const getTimeText = () => {
     if (!bestSubmission) {
-      return '';
+      return <p />;
     }
 
     // Calculate time from start of game till best submission
@@ -76,25 +89,38 @@ function Podium(props: PodiumProps) {
     const diffMilliseconds = new Date(bestSubmission.startTime).getTime() - startTime;
     const diffMinutes = Math.floor(diffMilliseconds / (60 * 1000));
 
-    return `in <b>${diffMinutes} minutes</b>`;
+    return (
+      <SmallerMediumText>
+        in
+        <b>{` ${diffMinutes} minutes`}</b>
+      </SmallerMediumText>
+    );
   };
 
   const getLanguageText = () => {
     if (!bestSubmission) {
-      return '';
+      return <p />;
     }
-
-    return `Language: <b>${bestSubmission.language as Language}</b>`;
+    // console.log(bestSubmission);
+    // console.log(fromString(bestSubmission.language));
+    // console.log(bestSubmission.language as Language);
+    // debugger;
+    return (
+      <SmallerMediumText>
+        Language:
+        <b>{` ${displayNameFromLanguage(bestSubmission.language as Language)}`}</b>
+      </SmallerMediumText>
+    );
   };
 
   return (
     <PodiumContainer>
       <Medal color="yellow" />
-      <MediumText>{getScoreText()}</MediumText>
-      <SmallerMediumText>{getTimeText()}</SmallerMediumText>
+      {getScoreText()}
+      {getTimeText()}
 
       <BottomContent>
-        <SmallerMediumText>{getLanguageText()}</SmallerMediumText>
+        {getLanguageText()}
       </BottomContent>
     </PodiumContainer>
   );

--- a/frontend/src/components/special/Podium.tsx
+++ b/frontend/src/components/special/Podium.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { Player } from '../../api/Game';
-import { MediumText } from '../core/Text';
+import { Player, Submission } from '../../api/Game';
+import { MediumText, SmallerMediumText } from '../core/Text';
 
 type PodiumProps = {
   place: string,
   player?: Player,
+  gameStartTime: string,
 };
 
 type MedalProps = {
@@ -34,12 +35,35 @@ const Medal = styled.div<MedalProps>`
 `;
 
 function Podium(props: PodiumProps) {
-  const { place, player } = props;
+  const { place, player, gameStartTime } = props;
+
+  const [bestSubmission, setBestSubmission] = useState<Submission | null>(null);
+
+  useEffect(() => {
+    if (player) {
+      // Find best submission
+      player.submissions.forEach((submission) => {
+        if (!bestSubmission || submission.numCorrect > bestSubmission.numCorrect) {
+          setBestSubmission(submission);
+        }
+      });
+    }
+  }, [player, setBestSubmission]);
+
+  const getScoreText = () => {
+    if (!bestSubmission) {
+      return '';
+    }
+
+    const percent = Math.round((bestSubmission.numCorrect / bestSubmission.numTestCases) * 100);
+    return `Scored <b>${percent}%</b>`;
+  };
 
   return (
     <PodiumContainer>
       <Medal color="yellow" />
-      <MediumText>temp</MediumText>
+      <MediumText>{getScoreText()}</MediumText>
+      <SmallerMediumText>{getTimeText()}</SmallerMediumText>
       Score
       Time
       Language

--- a/frontend/src/components/special/Podium.tsx
+++ b/frontend/src/components/special/Podium.tsx
@@ -8,6 +8,7 @@ type PodiumProps = {
   place: number,
   player: Player | undefined,
   gameStartTime: string,
+  inviteContent: React.ReactNode,
   loading: boolean,
 };
 
@@ -71,7 +72,7 @@ const Medal = styled.div<MedalProps>`
 
 function Podium(props: PodiumProps) {
   const {
-    place, player, gameStartTime, loading,
+    place, player, gameStartTime, loading, inviteContent,
   } = props;
 
   const [bestSubmission, setBestSubmission] = useState<Submission | null>(null);
@@ -115,7 +116,10 @@ function Podium(props: PodiumProps) {
 
   const getScoreText = () => {
     if (!player) {
-      return <ScoreText>{loading ? 'Loading...' : 'Invite'}</ScoreText>;
+      if (loading) {
+        return <ScoreText>{loading ? 'Loading...' : 'Invite'}</ScoreText>;
+      }
+      return inviteContent;
     }
 
     if (!bestSubmission) {

--- a/frontend/src/components/special/Podium.tsx
+++ b/frontend/src/components/special/Podium.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Player } from '../../api/Game';
+
+type PodiumProps = {
+  place: string,
+  player?: Player,
+};
+
+type MedalProps = {
+  place: number,
+  player?: Player,
+};
+
+const PodiumContainer = styled.div`
+  display: block;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+  width: 300px;
+  height: 500px;
+  padding: 10px;
+  margin: 20px;
+  background: ${({ theme }) => theme.colors.white};
+  border-radius: 8px;
+`;
+
+const Medal = styled.div<MedalProps>`
+  background: ${({ theme }) => theme.colors.gradients.yellow};
+  border-radius: 50%;
+  margin: 0 auto;
+  
+  height: 50px;
+  width: 50px;  
+  line-height: 50px;
+`;
+
+function Podium(props: PodiumProps) {
+  const { place } = props;
+
+  return (
+    <PodiumContainer>
+      <Medal />
+      Score
+      Time
+      Language
+    </PodiumContainer>
+  );
+}
+
+export default Podium;

--- a/frontend/src/components/special/Podium.tsx
+++ b/frontend/src/components/special/Podium.tsx
@@ -2,10 +2,11 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Player, Submission } from '../../api/Game';
 import { MediumText, SmallerMediumText } from '../core/Text';
+import Language from '../../api/Language';
 
 type PodiumProps = {
-  place: string,
-  player?: Player,
+  place: number,
+  player: Player | undefined,
   gameStartTime: string,
 };
 
@@ -22,6 +23,12 @@ const PodiumContainer = styled.div`
   margin: 20px;
   background: ${({ theme }) => theme.colors.white};
   border-radius: 8px;
+`;
+
+const BottomContent = styled.div`
+  position: absolute;
+  bottom: 5px;
+  left: 50%;
 `;
 
 const Medal = styled.div<MedalProps>`
@@ -59,14 +66,36 @@ function Podium(props: PodiumProps) {
     return `Scored <b>${percent}%</b>`;
   };
 
+  const getTimeText = () => {
+    if (!bestSubmission) {
+      return '';
+    }
+
+    // Calculate time from start of game till best submission
+    const startTime = new Date(gameStartTime).getTime();
+    const diffMilliseconds = new Date(bestSubmission.startTime).getTime() - startTime;
+    const diffMinutes = Math.floor(diffMilliseconds / (60 * 1000));
+
+    return `in <b>${diffMinutes} minutes</b>`;
+  };
+
+  const getLanguageText = () => {
+    if (!bestSubmission) {
+      return '';
+    }
+
+    return `Language: <b>${bestSubmission.language as Language}</b>`;
+  };
+
   return (
     <PodiumContainer>
       <Medal color="yellow" />
       <MediumText>{getScoreText()}</MediumText>
       <SmallerMediumText>{getTimeText()}</SmallerMediumText>
-      Score
-      Time
-      Language
+
+      <BottomContent>
+        <SmallerMediumText>{getLanguageText()}</SmallerMediumText>
+      </BottomContent>
     </PodiumContainer>
   );
 }

--- a/frontend/src/components/special/Podium.tsx
+++ b/frontend/src/components/special/Podium.tsx
@@ -90,7 +90,7 @@ function Podium(props: PodiumProps) {
 
       setBestSubmission(newBestSubmission);
     }
-  }, [player, setBestSubmission]);
+  }, [player, bestSubmission, setBestSubmission]);
 
   const getMedalColor = () => {
     switch (place) {

--- a/frontend/src/components/special/Podium.tsx
+++ b/frontend/src/components/special/Podium.tsx
@@ -110,8 +110,12 @@ function Podium(props: PodiumProps) {
   };
 
   const getScoreText = () => {
+    if (!player) {
+      return <ScoreText>{loading ? 'Loading...' : 'Invite'}</ScoreText>;
+    }
+
     if (!bestSubmission) {
-      return <ScoreText>{loading ? 'Scoring...' : 'Invite'}</ScoreText>;
+      return <ScoreText>{loading ? 'Loading...' : '0 submissions'}</ScoreText>;
     }
 
     const percent = Math.round((bestSubmission.numCorrect / bestSubmission.numTestCases) * 100);

--- a/frontend/src/components/special/Podium.tsx
+++ b/frontend/src/components/special/Podium.tsx
@@ -1,10 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Player, Submission } from '../../api/Game';
-import { SmallerMediumText, MediumText } from '../core/Text';
+import { Text, MediumText } from '../core/Text';
 import Language, { displayNameFromLanguage } from '../../api/Language';
-
-const totalPodiumHeight = 350;
 
 type PodiumProps = {
   place: number,
@@ -20,17 +18,17 @@ type HeightProps = {
   height: number,
 };
 
-const Content = styled.div<HeightProps>`
-  padding-top: ${({ height }) => (totalPodiumHeight - height) * 2}px;
-  display: inline-block;
-  justify-content: space-between;
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
 `;
 
 const PodiumContainer = styled.div<HeightProps>`
   position: relative;
   display: inline-block;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
-  width: 200px;
+  width: 180px;
   height: ${({ height }) => height}px;
   padding: 10px;
   margin: 10px;
@@ -46,6 +44,10 @@ const WinnerText = styled(MediumText)`
 const ScoreText = styled(MediumText)`
   font-weight: normal;
   margin: 0;
+`;
+
+const SmallerText = styled(Text)`
+  margin: 5px 0;
 `;
 
 const BottomContent = styled.div`
@@ -96,17 +98,17 @@ function Podium(props: PodiumProps) {
   const getPodiumHeight = () => {
     switch (place) {
       case 1:
-        return 320;
-      case 2:
         return 280;
-      default:
+      case 2:
         return 240;
+      default:
+        return 200;
     }
   };
 
   const getScoreText = () => {
     if (!bestSubmission) {
-      return <ScoreText>N/A</ScoreText>;
+      return <ScoreText />;
     }
 
     const percent = Math.round((bestSubmission.numCorrect / bestSubmission.numTestCases) * 100);
@@ -120,7 +122,7 @@ function Podium(props: PodiumProps) {
 
   const getTimeText = () => {
     if (!bestSubmission) {
-      return <SmallerMediumText>N/A</SmallerMediumText>;
+      return <SmallerText />;
     }
 
     // Calculate time from start of game till best submission
@@ -129,28 +131,28 @@ function Podium(props: PodiumProps) {
     const diffMinutes = Math.floor(diffMilliseconds / (60 * 1000));
 
     return (
-      <SmallerMediumText>
+      <SmallerText>
         in
         <b>{` ${diffMinutes} minutes`}</b>
-      </SmallerMediumText>
+      </SmallerText>
     );
   };
 
   const getLanguageText = () => {
     if (!bestSubmission) {
-      return <SmallerMediumText>Language: N/A</SmallerMediumText>;
+      return <SmallerText />;
     }
 
     return (
-      <SmallerMediumText>
+      <SmallerText>
         Language:
         <b>{` ${displayNameFromLanguage(bestSubmission.language as Language)}`}</b>
-      </SmallerMediumText>
+      </SmallerText>
     );
   };
 
   return (
-    <Content height={getPodiumHeight()}>
+    <Content>
       <div>
         <WinnerText>{player?.user.nickname || 'Invite'}</WinnerText>
         <PodiumContainer height={getPodiumHeight()}>

--- a/frontend/src/components/special/Podium.tsx
+++ b/frontend/src/components/special/Podium.tsx
@@ -115,7 +115,7 @@ function Podium(props: PodiumProps) {
     }
 
     if (!bestSubmission) {
-      return <ScoreText>{loading ? 'Loading...' : '0 submissions'}</ScoreText>;
+      return <ScoreText>{loading ? 'Loading...' : 'Scored 0'}</ScoreText>;
     }
 
     const percent = Math.round((bestSubmission.numCorrect / bestSubmission.numTestCases) * 100);

--- a/frontend/src/util/Utility.ts
+++ b/frontend/src/util/Utility.ts
@@ -1,3 +1,8 @@
+import { User } from '../api/User';
+import { removeUser } from '../api/Room';
+import { disconnect } from '../api/Socket';
+import { errorHandler } from '../api/Error';
+
 /**
  * Check whether all keys in param exist in location.state
  */
@@ -25,3 +30,23 @@ export const isValidRoomId = (roomIdParam: string): boolean => (roomIdParam.leng
  * the frontend Draggable test cases on the edit problem page.
  */
 export const generateRandomId = (): string => Math.random().toString(36);
+
+/**
+ * Remove a user or player from the given lobby or game
+ */
+export const leaveRoom = (history: any, roomId: string, user: User | null) => {
+  // eslint-disable-next-line no-alert
+  if (window.confirm('Are you sure you want to leave the room?')) {
+    if (user && user.userId) {
+      removeUser(roomId, {
+        initiator: user,
+        userToDelete: user,
+      });
+      disconnect();
+    }
+
+    history.replace('/game/join', {
+      error: errorHandler('You left the room.'),
+    });
+  }
+};

--- a/frontend/src/views/Game.tsx
+++ b/frontend/src/views/Game.tsx
@@ -16,7 +16,7 @@ import {
 import ErrorMessage from '../components/core/Error';
 import { ProblemHeaderText } from '../components/core/Text';
 import 'react-splitter-layout/lib/index.css';
-import { checkLocationState } from '../util/Utility';
+import { checkLocationState, leaveRoom } from '../util/Utility';
 import Console from '../components/game/Console';
 import Loading from '../components/core/Loading';
 import { User } from '../api/User';
@@ -31,7 +31,7 @@ import GameTimerContainer from '../components/game/GameTimerContainer';
 import { GameTimer } from '../api/GameTimer';
 import { TextButton } from '../components/core/Button';
 import {
-  connect, disconnect, routes, send, subscribe,
+  connect, routes, send, subscribe,
 } from '../api/Socket';
 import GameNotificationContainer from '../components/game/GameNotificationContainer';
 import Language from '../api/Language';
@@ -334,15 +334,6 @@ function GamePage() {
       });
   };
 
-  const exitGame = () => {
-    // eslint-disable-next-line no-alert
-    if (window.confirm('Exit the game? You will not be able to rejoin.')) {
-      disconnect()
-        .then(() => history.replace('/'))
-        .catch((err) => setError(err.message));
-    }
-  };
-
   const displayPlayerLeaderboard = useCallback(() => players.map((player, index) => (
     <LeaderboardCard
       player={player}
@@ -384,7 +375,7 @@ function GamePage() {
           <GameTimerContainer gameTimer={gameTimer || null} />
         </FlexCenter>
         <FlexRight>
-          <TextButton onClick={exitGame}>Exit Game</TextButton>
+          <TextButton onClick={() => leaveRoom(history, roomId, currentUser)}>Exit Game</TextButton>
         </FlexRight>
       </FlexInfoBar>
       <LeaderboardContent>

--- a/frontend/src/views/Join.tsx
+++ b/frontend/src/views/Join.tsx
@@ -73,7 +73,7 @@ function JoinGamePage() {
         .then((res) => {
           setLoading(false);
           if (res.active) {
-            setError('Cannot join a game that has already started.');
+            setError('This room has already started; please wait for the host to play again.');
           } else {
             setPageState(2);
           }

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -413,7 +413,7 @@ function LobbyPage() {
             connectUserToRoom(res.roomId, currentUser.userId);
           }
         })
-        .catch((err) => setError(err));
+        .catch((err) => setError(err.message));
     }
   };
 
@@ -456,7 +456,7 @@ function LobbyPage() {
           setStateFromRoom(res);
           updateCurrentUserDetails(res.users);
         })
-        .catch((err) => setError(err));
+        .catch((err) => setError(err.message));
     } else {
       // Get URL query params to determine if the roomId is provided.
       const urlParams = new URLSearchParams(window.location.search);

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -14,7 +14,7 @@ import {
   connect, routes, subscribe, disconnect,
 } from '../api/Socket';
 import { User } from '../api/User';
-import { checkLocationState, isValidRoomId } from '../util/Utility';
+import { checkLocationState, isValidRoomId, leaveRoom } from '../util/Utility';
 import { Difficulty } from '../api/Difficulty';
 import {
   PrimaryButton,
@@ -417,26 +417,6 @@ function LobbyPage() {
     }
   };
 
-  const leaveRoom = () => {
-    // eslint-disable-next-line no-alert
-    if (window.confirm('Are you sure you want to leave the room?')) {
-      if (currentUser && currentUser.userId) {
-        setLoading(true);
-        setError('');
-        removeUser(currentRoomId, {
-          initiator: currentUser,
-          userToDelete: currentUser,
-        });
-        disconnect();
-      }
-
-      // Redirect user regardless of POST request success.
-      history.replace('/game/join', {
-        error: errorHandler('You left the room.'),
-      });
-    }
-  };
-
   // Get current mouse position.
   const mouseMoveHandler = useCallback((e: MouseEvent) => {
     setMousePosition({ x: e.pageX, y: e.pageY });
@@ -550,7 +530,7 @@ function LobbyPage() {
         </HoverContainerPrimaryButton>
 
         <SecondaryRedButton
-          onClick={leaveRoom}
+          onClick={() => leaveRoom(history, currentRoomId, currentUser)}
         >
           Leave Room
         </SecondaryRedButton>

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -620,7 +620,7 @@ function LobbyPage() {
             </DifficultyContainer>
             <NoMarginMediumText>Duration</NoMarginMediumText>
             <NoMarginSubtitleText>
-              {`${duration} minutes`}
+              {`${duration} minute${duration === 1 ? '' : 's'}`}
             </NoMarginSubtitleText>
             <HoverContainerSlider>
               <HoverElementSlider

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -51,7 +51,7 @@ const HeaderContainer = styled.div`
   max-width: 500px;
   text-align: left;
   width: 66%;
-  margin: 2rem auto 0;
+  margin: 1rem auto 1rem auto;
 
   @media (max-width: 750px) {
     width: 80%;
@@ -439,7 +439,7 @@ function LobbyPage() {
 
   // Get current mouse position.
   const mouseMoveHandler = useCallback((e: MouseEvent) => {
-    setMousePosition({ x: e.clientX, y: e.clientY });
+    setMousePosition({ x: e.pageX, y: e.pageY });
   }, [setMousePosition]);
 
   useEffect(() => {

--- a/frontend/src/views/Lobby.tsx
+++ b/frontend/src/views/Lobby.tsx
@@ -51,7 +51,7 @@ const HeaderContainer = styled.div`
   max-width: 500px;
   text-align: left;
   width: 66%;
-  margin: 1rem auto 1rem auto;
+  margin: 2rem auto 1rem auto;
 
   @media (max-width: 750px) {
     width: 80%;

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -167,7 +167,7 @@ function GameResultsPage() {
         x={mousePosition.x}
         y={mousePosition.y}
       >
-        Only the host can start the game and update settings
+        Only the host can restart the room
       </HoverTooltip>
       <LargeText>Winners</LargeText>
       <PodiumContainer>

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -9,7 +9,7 @@ import {
 import { checkLocationState } from '../util/Utility';
 import { errorHandler } from '../api/Error';
 import PlayerResultsCard from '../components/card/PlayerResultsCard';
-import { PrimaryButton } from '../components/core/Button';
+import { PrimaryButton, SecondaryRedButton } from '../components/core/Button';
 import ErrorMessage from '../components/core/Error';
 import Loading from '../components/core/Loading';
 import {
@@ -18,6 +18,7 @@ import {
 import { User } from '../api/User';
 import { ThemeConfig } from '../components/config/Theme';
 import Podium from '../components/special/Podium';
+import { removeUser } from '../api/Room';
 
 const Content = styled.div`
   padding: 0;
@@ -118,6 +119,25 @@ function GameResultsPage() {
       });
   };
 
+  const leaveRoom = () => {
+    // eslint-disable-next-line no-alert
+    if (window.confirm('Are you sure you want to leave the room?')) {
+      if (currentUser && currentUser.userId) {
+        setLoading(true);
+        setError('');
+        removeUser(roomId, {
+          initiator: currentUser,
+          userToDelete: currentUser,
+        });
+        disconnect();
+      }
+
+      history.replace('/game/join', {
+        error: errorHandler('You left the game.'),
+      });
+    }
+  };
+
   return (
     <Content>
       { error ? <ErrorMessage message={error} /> : null }
@@ -129,18 +149,36 @@ function GameResultsPage() {
           place={2}
           player={players[1]}
           gameStartTime={startTime}
+          loading={loading}
         />
         <Podium
           place={1}
           player={players[0]}
           gameStartTime={startTime}
+          loading={loading}
         />
         <Podium
           place={3}
           player={players[2]}
           gameStartTime={startTime}
+          loading={loading}
         />
       </PodiumContainer>
+
+      <div>
+        <PrimaryButton
+          color={ThemeConfig.colors.gradients.blue}
+          onClick={callPlayAgain}
+          disabled={!currentUser || currentUser?.userId !== host?.userId}
+        >
+          Play Again
+        </PrimaryButton>
+        <SecondaryRedButton
+          onClick={leaveRoom}
+        >
+          Leave Room
+        </SecondaryRedButton>
+      </div>
 
       {players?.map((player, index) => (
         <PlayerResultsCard
@@ -156,6 +194,7 @@ function GameResultsPage() {
           <PrimaryButton
             color={ThemeConfig.colors.gradients.blue}
             onClick={callPlayAgain}
+            title="Only the host can perform this action."
           >
             Play Again
           </PrimaryButton>

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useLocation, useHistory } from 'react-router-dom';
 import { Message } from 'stompjs';
@@ -19,6 +19,8 @@ import { User } from '../api/User';
 import { ThemeConfig } from '../components/config/Theme';
 import Podium from '../components/special/Podium';
 import { removeUser } from '../api/Room';
+import { HoverContainer, HoverElement, HoverTooltip } from '../components/core/HoverTooltip';
+import { Coordinate } from '../components/special/FloatingCircle';
 
 const Content = styled.div`
   padding: 0;
@@ -46,6 +48,9 @@ function GameResultsPage() {
   const [host, setHost] = useState<User | null>(null);
   const [startTime, setStartTime] = useState<string>('');
   const [roomId, setRoomId] = useState('');
+
+  const [mousePosition, setMousePosition] = useState<Coordinate>({ x: 0, y: 0 });
+  const [hoverVisible, setHoverVisible] = useState<boolean>(false);
 
   useEffect(() => {
     if (checkLocationState(location, 'roomId', 'currentUser')) {
@@ -138,8 +143,17 @@ function GameResultsPage() {
     }
   };
 
+  const isHost = useCallback((user: User | null) => user?.userId === host?.userId, [host]);
+
   return (
     <Content>
+      <HoverTooltip
+        visible={hoverVisible}
+        x={mousePosition.x}
+        y={mousePosition.y}
+      >
+        Only the host can start the game and update settings
+      </HoverTooltip>
       <LargeText>Winners</LargeText>
       <PodiumContainer>
         <Podium
@@ -163,13 +177,23 @@ function GameResultsPage() {
       </PodiumContainer>
 
       <div>
-        <PrimaryButton
-          color={ThemeConfig.colors.gradients.blue}
-          onClick={callPlayAgain}
-          disabled={!currentUser || currentUser?.userId !== host?.userId}
-        >
-          Play Again
-        </PrimaryButton>
+        <HoverContainer>
+          <HoverElement
+            onClick={callPlayAgain}
+            enabled={isHost(currentUser)}
+            onMouseEnter={() => {
+              if (!isHost(currentUser)) {
+                setHoverVisible(true);
+              }
+            }}
+            onMouseLeave={() => {
+              if (!isHost(currentUser)) {
+                setHoverVisible(false);
+              }
+            }}
+          />
+        </HoverContainer>
+
         <SecondaryRedButton
           onClick={leaveRoom}
         >

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -43,7 +43,7 @@ const PodiumContainer = styled.div`
 `;
 
 const InviteContainer = styled.div`
-  width: 70%;
+  width: 60%;
   margin: 20px auto 0 auto;
   border-radius: 5px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.24);
@@ -221,7 +221,7 @@ function GameResultsPage() {
       <div>
         <HoverContainer>
           <PrimaryButtonHoverElement
-            enabled={isHost(currentUser)}
+            enabled={!loading && isHost(currentUser)}
             onMouseEnter={() => {
               if (!isHost(currentUser)) {
                 setHoverVisible(true);

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -23,6 +23,14 @@ const Content = styled.div`
   padding: 0;
 `;
 
+const PodiumContainer = styled.div`
+  //position: relative;
+  //display: flex;
+  ////justify-content: flex-end;
+  //flex-direction: column;
+  //justify-content: space-between;
+`;
+
 type LocationState = {
   roomId: string,
   currentUser: User,
@@ -119,15 +127,15 @@ function GameResultsPage() {
       { loading ? <Loading /> : null }
       <LargeText>Winners</LargeText>
 
-      <div>
-        <Podium
-          place={1}
-          player={players[0]}
-          gameStartTime={startTime}
-        />
+      <PodiumContainer>
         <Podium
           place={2}
           player={players[1]}
+          gameStartTime={startTime}
+        />
+        <Podium
+          place={1}
+          player={players[0]}
           gameStartTime={startTime}
         />
         <Podium
@@ -135,7 +143,7 @@ function GameResultsPage() {
           player={players[2]}
           gameStartTime={startTime}
         />
-      </div>
+      </PodiumContainer>
 
       {players?.map((player, index) => (
         <PlayerResultsCard

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -164,15 +164,20 @@ function GameResultsPage() {
     window.onmousemove = mouseMoveHandler;
   }, [mouseMoveHandler]);
 
+  // Reset hover status on host changes
+  useEffect(() => {
+    setHoverVisible(false);
+  }, [host]);
+
   // Content to display for inviting players (if not enough players on the podium)
   const inviteContent = () => (
-    <InviteContainer>
-      <InviteText
-        onClick={() => {
-          copy(`https://codejoust.co/play?room=${roomId}`);
-          setCopiedRoomLink(true);
-        }}
-      >
+    <InviteContainer
+      onClick={() => {
+        copy(`https://codejoust.co/play?room=${roomId}`);
+        setCopiedRoomLink(true);
+      }}
+    >
+      <InviteText>
         Invite
         <InlineCopyIcon>content_copy</InlineCopyIcon>
       </InviteText>

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -26,6 +26,13 @@ const Content = styled.div`
   padding: 0;
 `;
 
+const PrimaryButtonHoverElement = styled(HoverElement)`
+  width: 10rem;
+  height: 2.75rem;
+  top: 1.2rem;
+  left: 1.2rem;
+`;
+
 const PodiumContainer = styled.div`
   display: flex;
   justify-content: center;
@@ -145,6 +152,15 @@ function GameResultsPage() {
 
   const isHost = useCallback((user: User | null) => user?.userId === host?.userId, [host]);
 
+  // Get current mouse position.
+  const mouseMoveHandler = useCallback((e: MouseEvent) => {
+    setMousePosition({ x: e.clientX, y: e.clientY });
+  }, [setMousePosition]);
+
+  useEffect(() => {
+    window.onmousemove = mouseMoveHandler;
+  }, [mouseMoveHandler]);
+
   return (
     <Content>
       <HoverTooltip
@@ -178,7 +194,7 @@ function GameResultsPage() {
 
       <div>
         <HoverContainer>
-          <HoverElement
+          <PrimaryButtonHoverElement
             onClick={callPlayAgain}
             enabled={isHost(currentUser)}
             onMouseEnter={() => {
@@ -192,6 +208,12 @@ function GameResultsPage() {
               }
             }}
           />
+          <PrimaryButton
+            onClick={callPlayAgain}
+            disabled={!currentUser || currentUser?.userId !== host?.userId}
+          >
+            Play Again
+          </PrimaryButton>
         </HoverContainer>
 
         <SecondaryRedButton

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -140,10 +140,7 @@ function GameResultsPage() {
 
   return (
     <Content>
-      { error ? <ErrorMessage message={error} /> : null }
-      { loading ? <Loading /> : null }
       <LargeText>Winners</LargeText>
-
       <PodiumContainer>
         <Podium
           place={2}
@@ -180,6 +177,10 @@ function GameResultsPage() {
         </SecondaryRedButton>
       </div>
 
+      { error ? <ErrorMessage message={error} /> : null }
+      { loading ? <Loading /> : null }
+
+      {/* TODO: convert to table */}
       {players?.map((player, index) => (
         <PlayerResultsCard
           player={player}
@@ -188,18 +189,6 @@ function GameResultsPage() {
           color={player.color}
         />
       ))}
-
-      {currentUser && currentUser?.userId === host?.userId
-        ? (
-          <PrimaryButton
-            color={ThemeConfig.colors.gradients.blue}
-            onClick={callPlayAgain}
-            title="Only the host can perform this action."
-          >
-            Play Again
-          </PrimaryButton>
-        )
-        : <Text>{!loading && 'Waiting for the host to choose whether to play again...'}</Text>}
     </Content>
   );
 }

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -17,6 +17,7 @@ import {
 } from '../api/Socket';
 import { User } from '../api/User';
 import { ThemeConfig } from '../components/config/Theme';
+import Podium from '../components/special/Podium';
 
 const Content = styled.div`
   padding: 0 20%;
@@ -37,6 +38,7 @@ function GameResultsPage() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [host, setHost] = useState<User | null>(null);
+  const [startTime, setStartTime] = useState<string>('');
   const [roomId, setRoomId] = useState('');
 
   useEffect(() => {
@@ -58,6 +60,7 @@ function GameResultsPage() {
       const subscribeCallback = (result: Message) => {
         const updatedGame: Game = JSON.parse(result.body);
 
+        setStartTime(updatedGame.gameTimer.startTime);
         // Update leaderboard with last second submissions
         setPlayers(updatedGame.players);
         // Set new host if the previous host refreshes or leaves
@@ -82,6 +85,7 @@ function GameResultsPage() {
               setLoading(false);
               setPlayers(res.players);
               setHost(res.room.host);
+              setStartTime(res.gameTimer.startTime);
 
               // Check if host elected to play again
               if (res.playAgain) {
@@ -114,6 +118,13 @@ function GameResultsPage() {
       { error ? <ErrorMessage message={error} /> : null }
       { loading ? <Loading /> : null }
       <LargeText>Winners</LargeText>
+
+      <Podium
+        place={1}
+        player={players[0]}
+        gameStartTime={startTime}
+      />
+
       {players?.map((player, index) => (
         <PlayerResultsCard
           player={player}

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useLocation, useHistory } from 'react-router-dom';
 import { Message } from 'stompjs';
-import { LargeText, Text } from '../components/core/Text';
+import { LargeText } from '../components/core/Text';
 import {
   getGame, Game, Player, playAgain,
 } from '../api/Game';
@@ -16,7 +16,6 @@ import {
   connect, disconnect, routes, subscribe,
 } from '../api/Socket';
 import { User } from '../api/User';
-import { ThemeConfig } from '../components/config/Theme';
 import Podium from '../components/special/Podium';
 import { removeUser } from '../api/Room';
 import { HoverContainer, HoverElement, HoverTooltip } from '../components/core/HoverTooltip';
@@ -154,7 +153,7 @@ function GameResultsPage() {
 
   // Get current mouse position.
   const mouseMoveHandler = useCallback((e: MouseEvent) => {
-    setMousePosition({ x: e.clientX, y: e.clientY });
+    setMousePosition({ x: e.pageX, y: e.pageY });
   }, [setMousePosition]);
 
   useEffect(() => {

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -20,7 +20,7 @@ import { ThemeConfig } from '../components/config/Theme';
 import Podium from '../components/special/Podium';
 
 const Content = styled.div`
-  padding: 0 20%;
+  padding: 0;
 `;
 
 type LocationState = {
@@ -119,11 +119,23 @@ function GameResultsPage() {
       { loading ? <Loading /> : null }
       <LargeText>Winners</LargeText>
 
-      <Podium
-        place={1}
-        player={players[0]}
-        gameStartTime={startTime}
-      />
+      <div>
+        <Podium
+          place={1}
+          player={players[0]}
+          gameStartTime={startTime}
+        />
+        <Podium
+          place={2}
+          player={players[1]}
+          gameStartTime={startTime}
+        />
+        <Podium
+          place={3}
+          player={players[2]}
+          gameStartTime={startTime}
+        />
+      </div>
 
       {players?.map((player, index) => (
         <PlayerResultsCard

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -194,7 +194,6 @@ function GameResultsPage() {
       <div>
         <HoverContainer>
           <PrimaryButtonHoverElement
-            onClick={callPlayAgain}
             enabled={isHost(currentUser)}
             onMouseEnter={() => {
               if (!isHost(currentUser)) {
@@ -209,7 +208,7 @@ function GameResultsPage() {
           />
           <PrimaryButton
             onClick={callPlayAgain}
-            disabled={!currentUser || currentUser?.userId !== host?.userId}
+            disabled={loading || !isHost(currentUser)}
           >
             Play Again
           </PrimaryButton>

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -24,11 +24,8 @@ const Content = styled.div`
 `;
 
 const PodiumContainer = styled.div`
-  //position: relative;
-  //display: flex;
-  ////justify-content: flex-end;
-  //flex-direction: column;
-  //justify-content: space-between;
+  display: flex;
+  justify-content: center;
 `;
 
 type LocationState = {

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -6,7 +6,7 @@ import { LargeText } from '../components/core/Text';
 import {
   getGame, Game, Player, playAgain,
 } from '../api/Game';
-import { checkLocationState } from '../util/Utility';
+import { checkLocationState, leaveRoom } from '../util/Utility';
 import { errorHandler } from '../api/Error';
 import PlayerResultsCard from '../components/card/PlayerResultsCard';
 import { PrimaryButton, SecondaryRedButton } from '../components/core/Button';
@@ -17,7 +17,6 @@ import {
 } from '../api/Socket';
 import { User } from '../api/User';
 import Podium from '../components/special/Podium';
-import { removeUser } from '../api/Room';
 import { HoverContainer, HoverElement, HoverTooltip } from '../components/core/HoverTooltip';
 import { Coordinate } from '../components/special/FloatingCircle';
 
@@ -130,25 +129,6 @@ function GameResultsPage() {
       });
   };
 
-  const leaveRoom = () => {
-    // eslint-disable-next-line no-alert
-    if (window.confirm('Are you sure you want to leave the room?')) {
-      if (currentUser && currentUser.userId) {
-        setLoading(true);
-        setError('');
-        removeUser(roomId, {
-          initiator: currentUser,
-          userToDelete: currentUser,
-        });
-        disconnect();
-      }
-
-      history.replace('/game/join', {
-        error: errorHandler('You left the game.'),
-      });
-    }
-  };
-
   const isHost = useCallback((user: User | null) => user?.userId === host?.userId, [host]);
 
   // Get current mouse position.
@@ -215,7 +195,7 @@ function GameResultsPage() {
         </HoverContainer>
 
         <SecondaryRedButton
-          onClick={leaveRoom}
+          onClick={() => leaveRoom(history, roomId, currentUser)}
         >
           Leave Room
         </SecondaryRedButton>

--- a/frontend/src/views/Results.tsx
+++ b/frontend/src/views/Results.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
+import copy from 'copy-to-clipboard';
 import { useLocation, useHistory } from 'react-router-dom';
 import { Message } from 'stompjs';
 import { LargeText } from '../components/core/Text';
@@ -19,6 +20,11 @@ import { User } from '../api/User';
 import Podium from '../components/special/Podium';
 import { HoverContainer, HoverElement, HoverTooltip } from '../components/core/HoverTooltip';
 import { Coordinate } from '../components/special/FloatingCircle';
+import {
+  CopyIndicator,
+  CopyIndicatorContainer,
+  InlineCopyIcon,
+} from '../components/special/CopyIndicator';
 
 const Content = styled.div`
   padding: 0;
@@ -34,6 +40,23 @@ const PrimaryButtonHoverElement = styled(HoverElement)`
 const PodiumContainer = styled.div`
   display: flex;
   justify-content: center;
+`;
+
+const InviteContainer = styled.div`
+  width: 70%;
+  margin: 20px auto 0 auto;
+  border-radius: 5px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.24);
+  padding: 5px;
+  
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const InviteText = styled.p`
+  margin: 0;
+  font-size: ${({ theme }) => theme.fontSize.mediumLarge};
 `;
 
 type LocationState = {
@@ -56,6 +79,7 @@ function GameResultsPage() {
 
   const [mousePosition, setMousePosition] = useState<Coordinate>({ x: 0, y: 0 });
   const [hoverVisible, setHoverVisible] = useState<boolean>(false);
+  const [copiedRoomLink, setCopiedRoomLink] = useState<boolean>(false);
 
   useEffect(() => {
     if (checkLocationState(location, 'roomId', 'currentUser')) {
@@ -140,8 +164,28 @@ function GameResultsPage() {
     window.onmousemove = mouseMoveHandler;
   }, [mouseMoveHandler]);
 
+  // Content to display for inviting players (if not enough players on the podium)
+  const inviteContent = () => (
+    <InviteContainer>
+      <InviteText
+        onClick={() => {
+          copy(`https://codejoust.co/play?room=${roomId}`);
+          setCopiedRoomLink(true);
+        }}
+      >
+        Invite
+        <InlineCopyIcon>content_copy</InlineCopyIcon>
+      </InviteText>
+    </InviteContainer>
+  );
+
   return (
     <Content>
+      <CopyIndicatorContainer copied={copiedRoomLink}>
+        <CopyIndicator onClick={() => setCopiedRoomLink(false)}>
+          Link copied!&nbsp;&nbsp;✕
+        </CopyIndicator>
+      </CopyIndicatorContainer>
       <HoverTooltip
         visible={hoverVisible}
         x={mousePosition.x}
@@ -155,18 +199,21 @@ function GameResultsPage() {
           place={2}
           player={players[1]}
           gameStartTime={startTime}
+          inviteContent={inviteContent()}
           loading={loading}
         />
         <Podium
           place={1}
           player={players[0]}
           gameStartTime={startTime}
+          inviteContent={inviteContent()}
           loading={loading}
         />
         <Podium
           place={3}
           player={players[2]}
           gameStartTime={startTime}
+          inviteContent={inviteContent()}
           loading={loading}
         />
       </PodiumContainer>

--- a/src/main/java/com/rocketden/main/exception/RoomError.java
+++ b/src/main/java/com/rocketden/main/exception/RoomError.java
@@ -14,7 +14,7 @@ public enum RoomError implements ApiError {
     NO_HOST(HttpStatus.BAD_REQUEST, "There is no host provided."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "A room could not be found with the given id."),
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "A user with the nickname provided has already joined the room."),
-    ALREADY_ACTIVE(HttpStatus.FORBIDDEN, "Cannot join a room that is already active.");
+    ALREADY_ACTIVE(HttpStatus.FORBIDDEN, "This room has already started; please wait for the host to play again.");
 
     private final HttpStatus status;
     private final ApiErrorResponse response;

--- a/src/main/java/com/rocketden/main/service/GameManagementService.java
+++ b/src/main/java/com/rocketden/main/service/GameManagementService.java
@@ -108,6 +108,8 @@ public class GameManagementService {
             throw new ApiException(GameError.GAME_NOT_OVER);
         }
 
+        // TODO: use repository to get updated info if player leaves room
+
         Room room = game.getRoom();
         User initiator = UserMapper.toEntity(request.getInitiator());
         if (!room.getHost().equals(initiator)) {

--- a/src/main/java/com/rocketden/main/service/GameManagementService.java
+++ b/src/main/java/com/rocketden/main/service/GameManagementService.java
@@ -108,9 +108,13 @@ public class GameManagementService {
             throw new ApiException(GameError.GAME_NOT_OVER);
         }
 
-        // TODO: use repository to get updated info if player leaves room
+        // Get up to date room using repository
+        Room room = repository.findRoomByRoomId(game.getRoom().getRoomId());
 
-        Room room = game.getRoom();
+        if (room == null) {
+            throw new ApiException(RoomError.NOT_FOUND);
+        }
+
         User initiator = UserMapper.toEntity(request.getInitiator());
         if (!room.getHost().equals(initiator)) {
             throw new ApiException(GameError.INVALID_PERMISSIONS);


### PR DESCRIPTION
### List of Changes:

* Create podium design for results page
* Display top 3 winners (if they exist) with scores, language, and submission time
* Allow users to leave room on results page
  * This required some updated backend code, which I made sure to add testing for
* Various small styling changes and bug fixes
  * Leaderboard on game page previously displayed latest rather than best submission
  * Slightly off margin/positioning for lobby header and hover tooltip
  * Singularize/pluralize usages of minutes (1 minute vs. X minutes)
  * New language helper method to convert from enum to display name

### Notes:

* The results page is not finished yet (still has the previous list display below the podium which is far from polished). The next PR will add the following:
  * Table display for all players below the podium
  * Popup for feedback and/or subscription to a mailing list
  * Maybe viewing other players' code if it's not too difficult
* There are a lot of edge cases for the podium such as loading stage, whether there are 3 players, if the 1/2/3 ranked player even submitted, etc. I accounted for all the edge cases I could find with different podium text, but might have missed something/could probably do better with some of those designs
* The podium design as expected is not well fitted to mobile-size screens

### Screencast and Images:

<img width="1510" alt="Podium design" src="https://user-images.githubusercontent.com/24768574/112453808-4c5e2500-8d15-11eb-834d-044bbffb51e3.png">


[Screencast of changes](https://www.loom.com/share/e235569110054491bd82979d979c777b) 


