### PR TITLE
problem approval functionality added in backend

### DIFF
--- a/src/main/java/com/rocketden/main/dao/ProblemRepository.java
+++ b/src/main/java/com/rocketden/main/dao/ProblemRepository.java
@@ -14,7 +14,6 @@ public interface ProblemRepository extends CrudRepository<Problem, Integer> {
     Problem findProblemByProblemId(String problemId);
     List<Problem> findAllByDifficultyAndApproval(ProblemDifficulty difficulty, Boolean approval);
     List<Problem> findAllByApproval(Boolean approval);
-    List<Problem> findAllByDifficulty(ProblemDifficulty difficulty);
     @Override
     List<Problem> findAll();
 }

--- a/src/main/java/com/rocketden/main/dao/ProblemRepository.java
+++ b/src/main/java/com/rocketden/main/dao/ProblemRepository.java
@@ -12,8 +12,9 @@ import java.util.List;
 public interface ProblemRepository extends CrudRepository<Problem, Integer> {
 
     Problem findProblemByProblemId(String problemId);
+    List<Problem> findAllByDifficultyAndApproval(ProblemDifficulty difficulty, Boolean approval);
+    List<Problem> findAllByApproval(Boolean approval);
     List<Problem> findAllByDifficulty(ProblemDifficulty difficulty);
-
     @Override
     List<Problem> findAll();
 }

--- a/src/main/java/com/rocketden/main/dto/problem/CreateProblemRequest.java
+++ b/src/main/java/com/rocketden/main/dto/problem/CreateProblemRequest.java
@@ -13,7 +13,6 @@ import lombok.Setter;
 public class CreateProblemRequest {
     private String name;
     private String description;
-    private Boolean approval;
     private ProblemDifficulty difficulty;
     private List<ProblemInputDto> problemInputs;
     private ProblemIOType outputType;

--- a/src/main/java/com/rocketden/main/dto/problem/CreateProblemRequest.java
+++ b/src/main/java/com/rocketden/main/dto/problem/CreateProblemRequest.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 public class CreateProblemRequest {
     private String name;
     private String description;
+    private Boolean approval;
     private ProblemDifficulty difficulty;
     private List<ProblemInputDto> problemInputs;
     private ProblemIOType outputType;

--- a/src/main/java/com/rocketden/main/dto/problem/ProblemDto.java
+++ b/src/main/java/com/rocketden/main/dto/problem/ProblemDto.java
@@ -17,6 +17,7 @@ public class ProblemDto {
     private String problemId;
     private String name;
     private String description;
+    private Boolean approval;
     private ProblemDifficulty difficulty;
     private List<ProblemTestCaseDto> testCases = new ArrayList<>();
     private List<ProblemInputDto> problemInputs;

--- a/src/main/java/com/rocketden/main/exception/ProblemError.java
+++ b/src/main/java/com/rocketden/main/exception/ProblemError.java
@@ -15,6 +15,7 @@ public enum ProblemError implements ApiError {
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "Please ensure each line of test case input/output is valid and is of the correct type."),
     INVALID_NUMBER_REQUEST(HttpStatus.BAD_REQUEST, "Please request a valid number of problems."),
     EMPTY_FIELD(HttpStatus.BAD_REQUEST, "Please enter a value for each required field."),
+    BAD_APPROVAL(HttpStatus.BAD_REQUEST, "Cannot approve a problem with no test cases."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "A problem could not be found with the given criteria.");
 
     private final HttpStatus status;

--- a/src/main/java/com/rocketden/main/model/problem/Problem.java
+++ b/src/main/java/com/rocketden/main/model/problem/Problem.java
@@ -33,6 +33,7 @@ public class Problem {
     private String problemId = UUID.randomUUID().toString();
     private String name;
     private Boolean approval = false;
+
     @Column(columnDefinition = "TEXT")
     private String description;
 

--- a/src/main/java/com/rocketden/main/model/problem/Problem.java
+++ b/src/main/java/com/rocketden/main/model/problem/Problem.java
@@ -70,5 +70,4 @@ public class Problem {
         problemInputs.add(problemInput);
         problemInput.setProblem(this);
     }
-
 }

--- a/src/main/java/com/rocketden/main/model/problem/Problem.java
+++ b/src/main/java/com/rocketden/main/model/problem/Problem.java
@@ -71,7 +71,4 @@ public class Problem {
         problemInput.setProblem(this);
     }
 
-    public void toggleApprovedStatus() {
-        approval ^= true;
-    }
 }

--- a/src/main/java/com/rocketden/main/model/problem/Problem.java
+++ b/src/main/java/com/rocketden/main/model/problem/Problem.java
@@ -31,8 +31,8 @@ public class Problem {
 
     // Auto-generate default business ID for each problem
     private String problemId = UUID.randomUUID().toString();
-
     private String name;
+    private Boolean approval = false;
     @Column(columnDefinition = "TEXT")
     private String description;
 
@@ -69,5 +69,9 @@ public class Problem {
     public void addProblemInput(ProblemInput problemInput) {
         problemInputs.add(problemInput);
         problemInput.setProblem(this);
+    }
+
+    public void toggleApprovedStatus() {
+        approval ^= true;
     }
 }

--- a/src/main/java/com/rocketden/main/service/ProblemService.java
+++ b/src/main/java/com/rocketden/main/service/ProblemService.java
@@ -62,7 +62,6 @@ public class ProblemService {
         problem.setDescription(request.getDescription());
         problem.setDifficulty(request.getDifficulty());
         problem.setOutputType(request.getOutputType());
-        problem.setApproval(request.getApproval());
 
         // Add all problem inputs in list.
         for (ProblemInputDto problemInput : request.getProblemInputs()) {

--- a/src/main/java/com/rocketden/main/service/ProblemService.java
+++ b/src/main/java/com/rocketden/main/service/ProblemService.java
@@ -179,10 +179,8 @@ public class ProblemService {
 
         List<Problem> problems;
         if (difficulty == ProblemDifficulty.RANDOM) {
-            //Change to findAllByApproval once it works
             problems = repository.findAllByApproval(true);
         } else {
-            //Change to findAllByDifficultyAndApproval once it works
             problems = repository.findAllByDifficultyAndApproval(difficulty, true);
         }
 

--- a/src/main/java/com/rocketden/main/service/ProblemService.java
+++ b/src/main/java/com/rocketden/main/service/ProblemService.java
@@ -62,6 +62,7 @@ public class ProblemService {
         problem.setDescription(request.getDescription());
         problem.setDifficulty(request.getDifficulty());
         problem.setOutputType(request.getOutputType());
+        problem.setApproval(request.getApproval());
 
         // Add all problem inputs in list.
         for (ProblemInputDto problemInput : request.getProblemInputs()) {
@@ -104,7 +105,9 @@ public class ProblemService {
                 || updatedProblem.getOutputType() == null) {
             throw new ApiException(ProblemError.EMPTY_FIELD);
         }
-
+        if (updatedProblem.getApproval() && updatedProblem.getTestCases().size() == 0) {
+            throw new ApiException(ProblemError.BAD_APPROVAL);
+        }
         if (updatedProblem.getDifficulty() == ProblemDifficulty.RANDOM) {
             throw new ApiException(ProblemError.BAD_DIFFICULTY);
         }
@@ -113,6 +116,7 @@ public class ProblemService {
         problem.setDescription(updatedProblem.getDescription());
         problem.setDifficulty(updatedProblem.getDifficulty());
         problem.setOutputType(updatedProblem.getOutputType());
+        problem.setApproval(updatedProblem.getApproval());
 
         problem.getProblemInputs().clear();
         for (ProblemInputDto problemInput : updatedProblem.getProblemInputs()) {
@@ -169,19 +173,21 @@ public class ProblemService {
             throw new ApiException(ProblemError.EMPTY_FIELD);
         }
 
+        if (numProblems <= 0) {
+            throw new ApiException(ProblemError.INVALID_NUMBER_REQUEST);
+        }
+
         List<Problem> problems;
         if (difficulty == ProblemDifficulty.RANDOM) {
-            problems = repository.findAll();
+            //Change to findAllByApproval once it works
+            problems = repository.findAllByApproval(true);
         } else {
-            problems = repository.findAllByDifficulty(difficulty);
+            //Change to findAllByDifficultyAndApproval once it works
+            problems = repository.findAllByDifficultyAndApproval(difficulty, true);
         }
 
         if (problems == null || problems.isEmpty()) {
             throw new ApiException(ProblemError.NOT_FOUND);
-        }
-
-        if (numProblems <= 0) {
-            throw new ApiException(ProblemError.INVALID_NUMBER_REQUEST);
         }
 
         // If the user wants more problems than exists, just return all of them

--- a/src/main/java/com/rocketden/main/service/ProblemService.java
+++ b/src/main/java/com/rocketden/main/service/ProblemService.java
@@ -102,12 +102,15 @@ public class ProblemService {
                 || updatedProblem.getDifficulty() == null
                 || updatedProblem.getProblemInputs() == null
                 || updatedProblem.getTestCases() == null
-                || updatedProblem.getOutputType() == null) {
+                || updatedProblem.getOutputType() == null
+                || updatedProblem.getApproval() == null) {
             throw new ApiException(ProblemError.EMPTY_FIELD);
         }
+
         if (updatedProblem.getApproval() && updatedProblem.getTestCases().size() == 0) {
             throw new ApiException(ProblemError.BAD_APPROVAL);
         }
+
         if (updatedProblem.getDifficulty() == ProblemDifficulty.RANDOM) {
             throw new ApiException(ProblemError.BAD_DIFFICULTY);
         }

--- a/src/test/java/com/rocketden/main/api/GameTests.java
+++ b/src/test/java/com/rocketden/main/api/GameTests.java
@@ -31,12 +31,8 @@ import com.rocketden.main.model.problem.ProblemDifficulty;
 import com.rocketden.main.model.problem.ProblemIOType;
 import com.rocketden.main.service.SubmitService;
 import com.rocketden.main.util.UtilityTestMethods;
-import com.rocketden.main.service.ProblemService;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -98,11 +94,6 @@ public class GameTests {
 
     // Predefine notification content.
     private static final String CONTENT = "[1, 2, 3]";
-
-    //ProblemService for editing the problem
-    @Spy
-    @InjectMocks
-    private ProblemService problemService;
 
     // Helper method to start the game for a given room
     private void startGameHelper(RoomDto room, UserDto host) throws Exception {

--- a/src/test/java/com/rocketden/main/api/GameTests.java
+++ b/src/test/java/com/rocketden/main/api/GameTests.java
@@ -124,7 +124,7 @@ public class GameTests {
         createProblemRequest.setName(NAME);
         createProblemRequest.setDescription(DESCRIPTION);
         createProblemRequest.setDifficulty(ProblemDifficulty.EASY);
-
+        createProblemRequest.setApproval(true);
         List<ProblemInputDto> problemInputs = new ArrayList<>();
         ProblemInputDto problemInput = new ProblemInputDto(INPUT_NAME, IO_TYPE);
         problemInputs.add(problemInput);

--- a/src/test/java/com/rocketden/main/api/GameTests.java
+++ b/src/test/java/com/rocketden/main/api/GameTests.java
@@ -159,6 +159,7 @@ public class GameTests {
 
         String testCaseJsonResponse = testCaseResult.getResponse().getContentAsString();
         ProblemTestCaseDto testCaseActual = UtilityTestMethods.toObject(testCaseJsonResponse, ProblemTestCaseDto.class);
+        problemActual.setTestCases(Collections.singletonList(testCaseActual));
 
         assertEquals(INPUT, testCaseActual.getInput());
         assertEquals(OUTPUT, testCaseActual.getOutput());
@@ -177,11 +178,6 @@ public class GameTests {
         problemDto.setOutputType(ProblemIOType.CHARACTER);
         problemDto.setName(NAME);
         problemDto.setApproval(true);
-
-        ProblemTestCaseDto testCaseDto = new ProblemTestCaseDto();
-        testCaseDto.setInput(INPUT);
-        testCaseDto.setOutput("a");
-        problemDto.setTestCases(Collections.singletonList(testCaseDto));
 
         // Edit problem with new values
         String endpoint = String.format(PUT_PROBLEM_EDIT, problemDto.getProblemId());

--- a/src/test/java/com/rocketden/main/api/GameTests.java
+++ b/src/test/java/com/rocketden/main/api/GameTests.java
@@ -124,7 +124,6 @@ public class GameTests {
         createProblemRequest.setName(NAME);
         createProblemRequest.setDescription(DESCRIPTION);
         createProblemRequest.setDifficulty(ProblemDifficulty.EASY);
-        createProblemRequest.setApproval(true);
         List<ProblemInputDto> problemInputs = new ArrayList<>();
         ProblemInputDto problemInput = new ProblemInputDto(INPUT_NAME, IO_TYPE);
         problemInputs.add(problemInput);
@@ -145,7 +144,6 @@ public class GameTests {
         assertEquals(createProblemRequest.getDifficulty(), problemActual.getDifficulty());
         assertEquals(problemInputs, problemActual.getProblemInputs());
         assertEquals(IO_TYPE, problemActual.getOutputType());
-        assertTrue(problemActual.getApproval());
         CreateTestCaseRequest createTestCaseRequest = new CreateTestCaseRequest();
         createTestCaseRequest.setInput(INPUT);
         createTestCaseRequest.setOutput(OUTPUT);

--- a/src/test/java/com/rocketden/main/api/GameTests.java
+++ b/src/test/java/com/rocketden/main/api/GameTests.java
@@ -175,7 +175,6 @@ public class GameTests {
      */
     private ProblemDto createSingleApprovedProblemAndTestCases() throws Exception {
         ProblemDto problemDto = createSingleProblemAndTestCases();
-        problemDto.setOutputType(ProblemIOType.CHARACTER);
         problemDto.setName(NAME);
         problemDto.setApproval(true);
 

--- a/src/test/java/com/rocketden/main/api/GameTests.java
+++ b/src/test/java/com/rocketden/main/api/GameTests.java
@@ -145,7 +145,7 @@ public class GameTests {
         assertEquals(createProblemRequest.getDifficulty(), problemActual.getDifficulty());
         assertEquals(problemInputs, problemActual.getProblemInputs());
         assertEquals(IO_TYPE, problemActual.getOutputType());
-
+        assertTrue(problemActual.getApproval());
         CreateTestCaseRequest createTestCaseRequest = new CreateTestCaseRequest();
         createTestCaseRequest.setInput(INPUT);
         createTestCaseRequest.setOutput(OUTPUT);
@@ -163,7 +163,6 @@ public class GameTests {
         assertEquals(INPUT, testCaseActual.getInput());
         assertEquals(OUTPUT, testCaseActual.getOutput());
         assertFalse(testCaseActual.isHidden());
-
         return problemActual;
     }
 

--- a/src/test/java/com/rocketden/main/api/GameTests.java
+++ b/src/test/java/com/rocketden/main/api/GameTests.java
@@ -25,13 +25,18 @@ import com.rocketden.main.game_object.CodeLanguage;
 import com.rocketden.main.game_object.GameTimer;
 import com.rocketden.main.game_object.NotificationType;
 import com.rocketden.main.model.User;
+import com.rocketden.main.model.problem.Problem;
 import com.rocketden.main.util.RoomTestMethods;
 import com.rocketden.main.model.problem.ProblemDifficulty;
 import com.rocketden.main.model.problem.ProblemIOType;
 import com.rocketden.main.service.SubmitService;
 import com.rocketden.main.util.UtilityTestMethods;
+import com.rocketden.main.service.ProblemService;
 
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,13 +51,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @SpringBootTest(properties = "spring.datasource.type=com.zaxxer.hikari.HikariDataSource")
@@ -78,6 +83,7 @@ public class GameTests {
     private static final String POST_SUBMISSION = "/api/v1/games/%s/submission";
     private static final String POST_NOTIFICATION = "/api/v1/games/%s/notification";
     private static final String POST_PROBLEM_CREATE = "/api/v1/problems";
+    private static final String PUT_PROBLEM_EDIT = "/api/v1/problems/%s";
     private static final String POST_TEST_CASE_CREATE = "/api/v1/problems/%s/test-case";
 
     // Predefine user and room attributes.
@@ -93,9 +99,14 @@ public class GameTests {
     // Predefine notification content.
     private static final String CONTENT = "[1, 2, 3]";
 
+    //ProblemService for editing the problem
+    @Spy
+    @InjectMocks
+    private ProblemService problemService;
+
     // Helper method to start the game for a given room
     private void startGameHelper(RoomDto room, UserDto host) throws Exception {
-        createSingleProblemAndTestCases();
+        createSingleApprovedProblemAndTestCases();
 
         StartGameRequest request = new StartGameRequest();
         request.setInitiator(host);
@@ -164,6 +175,36 @@ public class GameTests {
         return problemActual;
     }
 
+    /**
+     * Helper method that creates a problem with the approved boolean set to true.
+     *
+     * @return the created problem
+     * @throws Exception if anything wrong occurs
+     */
+    private ProblemDto createSingleApprovedProblemAndTestCases() throws Exception {
+        ProblemDto problemDto = createSingleProblemAndTestCases();
+        problemDto.setOutputType(ProblemIOType.CHARACTER);
+        problemDto.setName(NAME);
+        problemDto.setApproval(true);
+
+        ProblemTestCaseDto testCaseDto = new ProblemTestCaseDto();
+        testCaseDto.setInput(INPUT);
+        testCaseDto.setOutput("a");
+        problemDto.setTestCases(Collections.singletonList(testCaseDto));
+
+        // Edit problem with new values
+        String endpoint = String.format(PUT_PROBLEM_EDIT, problemDto.getProblemId());
+        this.mockMvc.perform(put(endpoint)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(UtilityTestMethods.convertObjectToJsonString(problemDto)))
+                .andDo(print()).andExpect(status().isOk())
+                .andReturn();
+
+        assertTrue(problemDto.getApproval());
+
+        return problemDto;
+    }
+
     @Test
     public void startAndGetGameSuccess() throws Exception {
         UserDto host = new UserDto();
@@ -184,7 +225,7 @@ public class GameTests {
         StartGameRequest request = new StartGameRequest();
         request.setInitiator(roomDto.getHost());
 
-        createSingleProblemAndTestCases();
+        createSingleApprovedProblemAndTestCases();
 
         result = this.mockMvc.perform(post(String.format(START_GAME, roomDto.getRoomId()))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/com/rocketden/main/api/ProblemTests.java
+++ b/src/test/java/com/rocketden/main/api/ProblemTests.java
@@ -104,7 +104,6 @@ class ProblemTests {
         createProblemRequest.setName(NAME);
         createProblemRequest.setDescription(DESCRIPTION);
         createProblemRequest.setDifficulty(ProblemDifficulty.EASY);
-        createProblemRequest.setApproval(true);
         List<ProblemInputDto> problemInputs = new ArrayList<>();
         ProblemInputDto problemInput = new ProblemInputDto(INPUT_NAME, IO_TYPE);
         problemInputs.add(problemInput);

--- a/src/test/java/com/rocketden/main/api/ProblemTests.java
+++ b/src/test/java/com/rocketden/main/api/ProblemTests.java
@@ -104,7 +104,7 @@ class ProblemTests {
         createProblemRequest.setName(NAME);
         createProblemRequest.setDescription(DESCRIPTION);
         createProblemRequest.setDifficulty(ProblemDifficulty.EASY);
-
+        createProblemRequest.setApproval(true);
         List<ProblemInputDto> problemInputs = new ArrayList<>();
         ProblemInputDto problemInput = new ProblemInputDto(INPUT_NAME, IO_TYPE);
         problemInputs.add(problemInput);

--- a/src/test/java/com/rocketden/main/api/ProblemTests.java
+++ b/src/test/java/com/rocketden/main/api/ProblemTests.java
@@ -1,5 +1,6 @@
 package com.rocketden.main.api;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -128,6 +129,38 @@ class ProblemTests {
         return problemActual;
     }
 
+    /**
+     * Helper method that creates a problem with the approved boolean set to true.
+     *
+     * @return the problem with approval set to true
+     * @throws Exception if anything wrong occurs
+     */
+    private ProblemDto createSingleApprovedProblem() throws Exception {
+        ProblemDto problemDto = createSingleProblem();
+        problemDto.setOutputType(ProblemIOType.CHARACTER);
+        problemDto.setName(NAME_2);
+        problemDto.setApproval(true);
+
+        ProblemTestCaseDto testCaseDto = new ProblemTestCaseDto();
+        testCaseDto.setInput(INPUT);
+        testCaseDto.setOutput("a");
+        problemDto.setTestCases(Collections.singletonList(testCaseDto));
+
+        // Edit problem with new values
+        String endpoint = String.format(PUT_PROBLEM_EDIT, problemDto.getProblemId());
+        MvcResult problemResult = this.mockMvc.perform(put(endpoint)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(UtilityTestMethods.convertObjectToJsonString(problemDto)))
+                .andDo(print()).andExpect(status().isOk())
+                .andReturn();
+
+        String problemJsonResponse = problemResult.getResponse().getContentAsString();
+        ProblemDto problemActual = UtilityTestMethods.toObject(problemJsonResponse, ProblemDto.class);
+
+        assertTrue(problemActual.getApproval());
+
+        return problemActual;
+    }
     @Test
     public void getProblemNonExistent() throws Exception {
         ApiError ERROR = ProblemError.NOT_FOUND;
@@ -509,7 +542,7 @@ class ProblemTests {
 
     @Test
     public void getRandomProblemSuccess() throws Exception {
-        ProblemDto problem = createSingleProblem();
+        ProblemDto problem = createSingleApprovedProblem();
 
         MvcResult result = this.mockMvc.perform(get(GET_PROBLEM_RANDOM)
                 .param(DIFFICULTY_KEY, "EASY")

--- a/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
@@ -329,7 +329,6 @@ public class ProblemServiceTests {
         Problem problem1 = new Problem();
         problem1.setDifficulty(ProblemDifficulty.MEDIUM);
         List<Problem> problems = Collections.singletonList(problem1);
-        //Mockito.doReturn(problems).when(repository).findAllByApproval(true);
 
         ApiException exception = assertThrows(ApiException.class, () ->
                 problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, 0));
@@ -342,8 +341,6 @@ public class ProblemServiceTests {
         Problem problem1 = new Problem();
         problem1.setDifficulty(ProblemDifficulty.MEDIUM);
         List<Problem> problems = Collections.singletonList(problem1);
-
-        //Mockito.doReturn(problems).when(repository).findAll();
 
         ApiException exception = assertThrows(ApiException.class, () ->
                 problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, -3));

--- a/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
@@ -276,7 +276,6 @@ public class ProblemServiceTests {
         Problem problem1 = new Problem();
         problem1.setDifficulty(ProblemDifficulty.MEDIUM);
         List<Problem> problems = Collections.singletonList(problem1);
-        // Should be findAllByDifficultyAndApproval()
         Mockito.doReturn(problems).when(repository).findAllByDifficultyAndApproval(ProblemDifficulty.MEDIUM, true);
 
         List<Problem> response = problemService.getProblemsFromDifficulty(ProblemDifficulty.MEDIUM, 1);
@@ -463,9 +462,6 @@ public class ProblemServiceTests {
 
         ProblemDto updatedProblem = ProblemMapper.toDto(problem);
         updatedProblem.setApproval(true);
-
-        List<ProblemTestCaseDto> emptyCases = new ArrayList<ProblemTestCaseDto>();
-        updatedProblem.setTestCases(emptyCases);
 
         String problemId = problem.getProblemId();
         ApiException exception = assertThrows(ApiException.class, () ->

--- a/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
@@ -176,7 +176,6 @@ public class ProblemServiceTests {
         problem.setApproval(true);
         List<Problem> expected = new ArrayList<>();
         expected.add(problem);
-        //do findAllByApproval once it works
         Mockito.doReturn(expected).when(repository).findAll();
 
         List<ProblemDto> response = problemService.getAllProblems();
@@ -186,6 +185,7 @@ public class ProblemServiceTests {
         assertEquals(NAME, response.get(0).getName());
         assertEquals(DESCRIPTION, response.get(0).getDescription());
         assertEquals(problem.getDifficulty(), response.get(0).getDifficulty());
+        assertTrue(problem.getApproval());
     }
 
     @Test
@@ -289,7 +289,6 @@ public class ProblemServiceTests {
         Problem problem1 = new Problem();
         problem1.setDifficulty(ProblemDifficulty.MEDIUM);
         List<Problem> problems = Collections.singletonList(problem1);
-        //do findAllByApproval once it works
         Mockito.doReturn(problems).when(repository).findAllByApproval(true);
 
         // Return correct problem when selecting random difficulty
@@ -302,7 +301,6 @@ public class ProblemServiceTests {
         Problem problem1 = new Problem();
         problem1.setDifficulty(ProblemDifficulty.MEDIUM);
         List<Problem> problems = Collections.singletonList(problem1);
-        //do findAllByApproval once it works
         Mockito.doReturn(problems).when(repository).findAllByApproval(true);
 
         // Return correct problem when selecting random difficulty
@@ -332,7 +330,6 @@ public class ProblemServiceTests {
         Problem problem1 = new Problem();
         problem1.setDifficulty(ProblemDifficulty.MEDIUM);
         List<Problem> problems = Collections.singletonList(problem1);
-        //do findAllByApproval once it works
         //Mockito.doReturn(problems).when(repository).findAllByApproval(true);
 
         ApiException exception = assertThrows(ApiException.class, () ->
@@ -346,7 +343,7 @@ public class ProblemServiceTests {
         Problem problem1 = new Problem();
         problem1.setDifficulty(ProblemDifficulty.MEDIUM);
         List<Problem> problems = Collections.singletonList(problem1);
-        //do findAllByApproval once it works
+
         //Mockito.doReturn(problems).when(repository).findAll();
 
         ApiException exception = assertThrows(ApiException.class, () ->
@@ -467,7 +464,7 @@ public class ProblemServiceTests {
         ProblemDto updatedProblem = ProblemMapper.toDto(problem);
         updatedProblem.setApproval(true);
 
-        ArrayList<ProblemTestCaseDto> emptyCases = new ArrayList<ProblemTestCaseDto>();
+        List<ProblemTestCaseDto> emptyCases = new ArrayList<ProblemTestCaseDto>();
         updatedProblem.setTestCases(emptyCases);
 
         String problemId = problem.getProblemId();

--- a/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
@@ -173,10 +173,10 @@ public class ProblemServiceTests {
         problem.setName(NAME);
         problem.setDescription(DESCRIPTION);
         problem.setDifficulty(ProblemDifficulty.EASY);
-
+        problem.setApproval(true);
         List<Problem> expected = new ArrayList<>();
         expected.add(problem);
-
+        //do findAllByApproval once it works
         Mockito.doReturn(expected).when(repository).findAll();
 
         List<ProblemDto> response = problemService.getAllProblems();
@@ -276,8 +276,8 @@ public class ProblemServiceTests {
         Problem problem1 = new Problem();
         problem1.setDifficulty(ProblemDifficulty.MEDIUM);
         List<Problem> problems = Collections.singletonList(problem1);
-
-        Mockito.doReturn(problems).when(repository).findAllByDifficulty(ProblemDifficulty.MEDIUM);
+        // Should be findAllByDifficultyAndApproval()
+        Mockito.doReturn(problems).when(repository).findAllByDifficultyAndApproval(ProblemDifficulty.MEDIUM, true);
 
         List<Problem> response = problemService.getProblemsFromDifficulty(ProblemDifficulty.MEDIUM, 1);
 
@@ -289,8 +289,8 @@ public class ProblemServiceTests {
         Problem problem1 = new Problem();
         problem1.setDifficulty(ProblemDifficulty.MEDIUM);
         List<Problem> problems = Collections.singletonList(problem1);
-
-        Mockito.doReturn(problems).when(repository).findAll();
+        //do findAllByApproval once it works
+        Mockito.doReturn(problems).when(repository).findAllByApproval(true);
 
         // Return correct problem when selecting random difficulty
         List<Problem> response = problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, 1);
@@ -302,8 +302,8 @@ public class ProblemServiceTests {
         Problem problem1 = new Problem();
         problem1.setDifficulty(ProblemDifficulty.MEDIUM);
         List<Problem> problems = Collections.singletonList(problem1);
-
-        Mockito.doReturn(problems).when(repository).findAll();
+        //do findAllByApproval once it works
+        Mockito.doReturn(problems).when(repository).findAllByApproval(true);
 
         // Return correct problem when selecting random difficulty
         List<Problem> response = problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, 3);
@@ -332,8 +332,8 @@ public class ProblemServiceTests {
         Problem problem1 = new Problem();
         problem1.setDifficulty(ProblemDifficulty.MEDIUM);
         List<Problem> problems = Collections.singletonList(problem1);
-
-        Mockito.doReturn(problems).when(repository).findAll();
+        //do findAllByApproval once it works
+        //Mockito.doReturn(problems).when(repository).findAllByApproval(true);
 
         ApiException exception = assertThrows(ApiException.class, () ->
                 problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, 0));
@@ -346,8 +346,8 @@ public class ProblemServiceTests {
         Problem problem1 = new Problem();
         problem1.setDifficulty(ProblemDifficulty.MEDIUM);
         List<Problem> problems = Collections.singletonList(problem1);
-
-        Mockito.doReturn(problems).when(repository).findAll();
+        //do findAllByApproval once it works
+        //Mockito.doReturn(problems).when(repository).findAll();
 
         ApiException exception = assertThrows(ApiException.class, () ->
                 problemService.getProblemsFromDifficulty(ProblemDifficulty.RANDOM, -3));
@@ -451,6 +451,30 @@ public class ProblemServiceTests {
                 problemService.editProblem(problemId, updatedProblem));
 
         assertEquals(ProblemError.INVALID_INPUT, exception.getError());
+    }
+    @Test
+    public void editProblemBadApproval() {
+        Problem problem = new Problem();
+        problem.setName(NAME);
+        problem.setDescription(DESCRIPTION);
+        problem.setDifficulty(ProblemDifficulty.MEDIUM);
+        problem.setOutputType(ProblemIOType.STRING);
+        ProblemInput problemInput = new ProblemInput(INPUT_NAME, IO_TYPE);
+        problem.addProblemInput(problemInput);
+
+        Mockito.doReturn(problem).when(repository).findProblemByProblemId(problem.getProblemId());
+
+        ProblemDto updatedProblem = ProblemMapper.toDto(problem);
+        updatedProblem.setApproval(true);
+
+        ArrayList<ProblemTestCaseDto> emptyCases = new ArrayList<ProblemTestCaseDto>();
+        updatedProblem.setTestCases(emptyCases);
+
+        String problemId = problem.getProblemId();
+        ApiException exception = assertThrows(ApiException.class, () ->
+                problemService.editProblem(problemId, updatedProblem));
+
+        assertEquals(ProblemError.BAD_APPROVAL, exception.getError());
     }
 
     @Test

--- a/src/test/java/com/rocketden/main/socket/GameSocketTests.java
+++ b/src/test/java/com/rocketden/main/socket/GameSocketTests.java
@@ -115,7 +115,7 @@ public class GameSocketTests {
         assertNotNull(room);
 
         // Create problems
-        SocketTestMethods.createSingleProblemAndTestCases(template, port);
+        SocketTestMethods.createSingleApprovedProblemAndTestCases(template, port);
 
         // Start game
         StartGameRequest startRequest = new StartGameRequest();

--- a/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
+++ b/src/test/java/com/rocketden/main/socket/RoomSocketTests.java
@@ -329,7 +329,7 @@ public class RoomSocketTests {
         String startGameEndpoint = String.format("%s/%s/start", baseRestEndpoint, room.getRoomId());
 
         // Create a problem that the game can find and attach to the room.
-        SocketTestMethods.createSingleProblemAndTestCases(template, port);
+        SocketTestMethods.createSingleApprovedProblemAndTestCases(template, port);
 
         RoomDto expected = template.exchange(startGameEndpoint, HttpMethod.POST, startGameEntity, RoomDto.class).getBody();
 

--- a/src/test/java/com/rocketden/main/util/SocketTestMethods.java
+++ b/src/test/java/com/rocketden/main/util/SocketTestMethods.java
@@ -95,6 +95,7 @@ public class SocketTestMethods {
         String createTestCaseEndpoint = String.format("http://localhost:%s/api/v1/problems/%s/test-case", port, problemActual.getProblemId());
 
         ProblemTestCaseDto testCaseActual = template.exchange(createTestCaseEndpoint, HttpMethod.POST, createTestCaseEntity, ProblemTestCaseDto.class).getBody();
+        problemActual.getTestCases().add(testCaseActual);
 
         assertNotNull(testCaseActual);
         assertEquals(INPUT, testCaseActual.getInput());
@@ -113,11 +114,6 @@ public class SocketTestMethods {
     public static void createSingleApprovedProblemAndTestCases(TestRestTemplate template, int port) throws Exception {
         ProblemDto problem = createSingleProblemAndTestCases(template, port);
         problem.setApproval(true);
-
-        ProblemTestCaseDto testCaseDto = new ProblemTestCaseDto();
-        testCaseDto.setInput(INPUT);
-        testCaseDto.setOutput("a");
-        problem.setTestCases(Collections.singletonList(testCaseDto));
 
         HttpEntity<ProblemDto> editProblemEntity = new HttpEntity<>(problem);
         String editProblemEndpoint = String.format("http://localhost:%s/api/v1/problems/%s", port, problem.getProblemId());

--- a/src/test/java/com/rocketden/main/util/SocketTestMethods.java
+++ b/src/test/java/com/rocketden/main/util/SocketTestMethods.java
@@ -23,12 +23,11 @@ import org.springframework.web.socket.sockjs.client.SockJsClient;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SocketTestMethods {
 
@@ -65,7 +64,7 @@ public class SocketTestMethods {
      * create a new problem
      * @throws Exception if anything wrong occurs
      */
-    public static void createSingleProblemAndTestCases(TestRestTemplate template, int port) throws Exception {
+    public static ProblemDto createSingleProblemAndTestCases(TestRestTemplate template, int port) throws Exception {
         CreateProblemRequest createProblemRequest = new CreateProblemRequest();
         createProblemRequest.setName(NAME);
         createProblemRequest.setDescription(DESCRIPTION);
@@ -101,5 +100,30 @@ public class SocketTestMethods {
         assertEquals(INPUT, testCaseActual.getInput());
         assertEquals(OUTPUT, testCaseActual.getOutput());
         assertFalse(testCaseActual.isHidden());
+
+        return problemActual;
+    }
+
+    /**
+     * Sets the approval for a new problem to true. Necessary for a number of tests
+     *
+     * @return the new problem
+     * @throws Exception if anything wrong occurs
+     */
+    public static void createSingleApprovedProblemAndTestCases(TestRestTemplate template, int port) throws Exception {
+        ProblemDto problem = createSingleProblemAndTestCases(template, port);
+        problem.setApproval(true);
+
+        ProblemTestCaseDto testCaseDto = new ProblemTestCaseDto();
+        testCaseDto.setInput(INPUT);
+        testCaseDto.setOutput("a");
+        problem.setTestCases(Collections.singletonList(testCaseDto));
+
+        HttpEntity<ProblemDto> editProblemEntity = new HttpEntity<>(problem);
+        String editProblemEndpoint = String.format("http://localhost:%s/api/v1/problems/%s", port, problem.getProblemId());
+
+        ProblemDto problemActual = template.exchange(editProblemEndpoint, HttpMethod.PUT, editProblemEntity, ProblemDto.class).getBody();
+
+        assertTrue(problemActual.getApproval());
     }
 }

--- a/src/test/java/com/rocketden/main/util/SocketTestMethods.java
+++ b/src/test/java/com/rocketden/main/util/SocketTestMethods.java
@@ -71,6 +71,7 @@ public class SocketTestMethods {
         createProblemRequest.setDescription(DESCRIPTION);
         createProblemRequest.setDifficulty(ProblemDifficulty.EASY);
         createProblemRequest.setApproval(true);
+
         List<ProblemInputDto> problemInputs = new ArrayList<>();
         ProblemInputDto problemInput = new ProblemInputDto(INPUT_NAME, IO_TYPE);
         problemInputs.add(problemInput);

--- a/src/test/java/com/rocketden/main/util/SocketTestMethods.java
+++ b/src/test/java/com/rocketden/main/util/SocketTestMethods.java
@@ -70,7 +70,6 @@ public class SocketTestMethods {
         createProblemRequest.setName(NAME);
         createProblemRequest.setDescription(DESCRIPTION);
         createProblemRequest.setDifficulty(ProblemDifficulty.EASY);
-        createProblemRequest.setApproval(true);
 
         List<ProblemInputDto> problemInputs = new ArrayList<>();
         ProblemInputDto problemInput = new ProblemInputDto(INPUT_NAME, IO_TYPE);
@@ -89,7 +88,6 @@ public class SocketTestMethods {
         assertEquals(createProblemRequest.getDifficulty(), problemActual.getDifficulty());
         assertEquals(problemInputs, problemActual.getProblemInputs());
         assertEquals(IO_TYPE, problemActual.getOutputType());
-        assertEquals(true, problemActual.getApproval());
         CreateTestCaseRequest createTestCaseRequest = new CreateTestCaseRequest();
         createTestCaseRequest.setInput(INPUT);
         createTestCaseRequest.setOutput(OUTPUT);

--- a/src/test/java/com/rocketden/main/util/SocketTestMethods.java
+++ b/src/test/java/com/rocketden/main/util/SocketTestMethods.java
@@ -88,7 +88,7 @@ public class SocketTestMethods {
         assertEquals(createProblemRequest.getDifficulty(), problemActual.getDifficulty());
         assertEquals(problemInputs, problemActual.getProblemInputs());
         assertEquals(IO_TYPE, problemActual.getOutputType());
-
+        assertEquals(true, problemActual.getApproval());
         CreateTestCaseRequest createTestCaseRequest = new CreateTestCaseRequest();
         createTestCaseRequest.setInput(INPUT);
         createTestCaseRequest.setOutput(OUTPUT);

--- a/src/test/java/com/rocketden/main/util/SocketTestMethods.java
+++ b/src/test/java/com/rocketden/main/util/SocketTestMethods.java
@@ -70,7 +70,7 @@ public class SocketTestMethods {
         createProblemRequest.setName(NAME);
         createProblemRequest.setDescription(DESCRIPTION);
         createProblemRequest.setDifficulty(ProblemDifficulty.EASY);
-
+        createProblemRequest.setApproval(true);
         List<ProblemInputDto> problemInputs = new ArrayList<>();
         ProblemInputDto problemInput = new ProblemInputDto(INPUT_NAME, IO_TYPE);
         problemInputs.add(problemInput);

--- a/src/test/java/com/rocketden/main/util/SocketTestMethods.java
+++ b/src/test/java/com/rocketden/main/util/SocketTestMethods.java
@@ -23,7 +23,6 @@ import org.springframework.web.socket.sockjs.client.SockJsClient;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static java.util.concurrent.TimeUnit.SECONDS;


### PR DESCRIPTION
### List of Changes:

- Added problem approval boolean to model/Problem.java
- Added toggleApproval() setter method in model/Problem.java
- Changed getProblemByDifficulty method to check approval in addition to difficulty (only approved problems can be picked)
- Changed ProblemService, GameSocket, Game, and Problem tests by setting every problem to approved when it's created
- Added an exception that prevents people from approving a problem through editProblem if it has zero test cases (Note: not yet tested if this actually works. It's possible that an empty test case will still make the index of the test case arrayList 1 and bypass this error. Can test in production)

### Notes:

- Tests passed (phew)