### PR TITLE
Check valid parameter names for problems on frontend and backend.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,7 +41,8 @@
         "stompjs": "^2.3.3",
         "styled-components": "^5.1.1",
         "typeface-roboto": "0.0.75",
-        "typescript": "~3.7.2"
+        "typescript": "~3.7.2",
+        "valid-identifier": "0.0.2"
       },
       "devDependencies": {
         "@types/react-beautiful-dnd": "^13.0.0",
@@ -13158,11 +13159,7 @@
     "node_modules/react-ga": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
-      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==",
-      "peerDependencies": {
-        "prop-types": "^15.6.0",
-        "react": "^15.6.2 || ^16.0 || ^17"
-      }
+      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ=="
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -16352,6 +16349,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
       "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
+    },
+    "node_modules/valid-identifier": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/valid-identifier/-/valid-identifier-0.0.2.tgz",
+      "integrity": "sha512-zaSmOW6ykXwrkX0YTuFUSoALNEKGaQHpxBJQLb3TXspRNDpBwbfrIQCZqAQ0LKBlKuyn2YOq7NNd6415hvZ33g=="
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -28707,8 +28709,7 @@
     "react-ga": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
-      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==",
-      "requires": {}
+      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ=="
     },
     "react-is": {
       "version": "16.13.1",
@@ -31411,6 +31412,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
       "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
+    },
+    "valid-identifier": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/valid-identifier/-/valid-identifier-0.0.2.tgz",
+      "integrity": "sha512-zaSmOW6ykXwrkX0YTuFUSoALNEKGaQHpxBJQLb3TXspRNDpBwbfrIQCZqAQ0LKBlKuyn2YOq7NNd6415hvZ33g=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,8 @@
     "stompjs": "^2.3.3",
     "styled-components": "^5.1.1",
     "typeface-roboto": "0.0.75",
-    "typescript": "~3.7.2"
+    "typescript": "~3.7.2",
+    "valid-identifier": "0.0.2"
   },
   "devDependencies": {
     "@types/react-beautiful-dnd": "^13.0.0",

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -205,10 +205,17 @@ export const InlineRefreshIcon = styled.i.attrs(() => ({
   }
 `;
 
-export const InlineErrorIcon = styled(InlineRefreshIcon).attrs(() => ({
-}))`
+type ShowError = {
+  show: boolean,
+};
+
+export const InlineErrorIcon = styled(InlineRefreshIcon).attrs((props: ShowError) => ({
+  style: {
+    display: props.show ? 'inline-block' : 'none',
+  },
+}))<ShowError>`
   color: ${({ theme }) => theme.colors.gray};
-  margin: 0;
+  margin: 0 0.5rem 0 0;
   padding: 0;
   box-shadow: none;
 

--- a/frontend/src/components/core/Button.tsx
+++ b/frontend/src/components/core/Button.tsx
@@ -204,3 +204,16 @@ export const InlineRefreshIcon = styled.i.attrs(() => ({
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.24);
   }
 `;
+
+export const InlineErrorIcon = styled(InlineRefreshIcon).attrs(() => ({
+}))`
+  color: ${({ theme }) => theme.colors.gray};
+  margin: 0;
+  padding: 0;
+  box-shadow: none;
+
+  &:hover {
+    cursor: default;
+    box-shadow: none;
+  }
+`;

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 import styled from 'styled-components';
@@ -39,7 +39,7 @@ import ErrorMessage from '../core/Error';
 import { InvertedSmallButtonLink } from '../core/Link';
 import { FlexBareContainer } from '../core/Container';
 import { generateRandomId, validIdentifier } from '../../util/Utility';
-import { HoverContainer, HoverElement, HoverTooltip } from '../core/HoverTooltip';
+import { HoverTooltip } from '../core/HoverTooltip';
 import { Coordinate } from '../special/FloatingCircle';
 
 const MainContent = styled.div`
@@ -65,23 +65,6 @@ const SettingsContainer = styled.div`
   border-radius: 10px;
   box-shadow: 0 -1px 4px rgba(0, 0, 0, 0.12);
   background: ${({ theme }) => theme.colors.white};
-`;
-
-type ShowError = {
-  show: boolean,
-};
-
-const HoverContainerErrorIcon = styled(HoverContainer).attrs((props: ShowError) => ({
-  style: {
-    display: `${props.show ? 'inline-block' : 'none'}`,
-  },
-}))<ShowError>`
-  margin: 0 0.5rem 0 0;
-`;
-
-const HoverElementErrorIcon = styled(HoverElement)`
-  width: 1rem;
-  height: 1rem;
 `;
 
 const SettingsContainerRelative = styled(SettingsContainer)`
@@ -178,13 +161,9 @@ function ProblemDisplay(props: ProblemDisplayParams) {
   const [hoverVisible, setHoverVisible] = useState<boolean>(false);
 
   // Get current mouse position.
-  const mouseMoveHandler = useCallback((e: MouseEvent) => {
+  const mouseMoveHandler = useCallback((e: any) => {
     setMousePosition({ x: e.pageX, y: e.pageY });
   }, [setMousePosition]);
-
-  useEffect(() => {
-    window.onmousemove = mouseMoveHandler;
-  }, [mouseMoveHandler]);
 
   const onDragEnd = (result: any) => {
     // dropped outside the list
@@ -487,18 +466,14 @@ function ProblemDisplay(props: ProblemDisplayParams) {
                   e.target.value, newProblem.problemInputs[index].type)}
               />
 
-              <HoverContainerErrorIcon
+              <InlineErrorIcon
                 show={!validIdentifier(newProblem.problemInputs[index].name)}
+                onMouseEnter={() => setHoverVisible(true)}
+                onMouseMove={mouseMoveHandler}
+                onMouseLeave={() => setHoverVisible(false)}
               >
-                <HoverElementErrorIcon
-                  enabled={validIdentifier(newProblem.problemInputs[index].name)}
-                  onMouseEnter={() => setHoverVisible(true)}
-                  onMouseLeave={() => setHoverVisible(false)}
-                />
-                <InlineErrorIcon>
-                  error_outline
-                </InlineErrorIcon>
-              </HoverContainerErrorIcon>
+                error_outline
+              </InlineErrorIcon>
 
               <PrimarySelect
                 onChange={(e) => handleInputChange(

--- a/frontend/src/components/problem/ProblemDisplay.tsx
+++ b/frontend/src/components/problem/ProblemDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 import styled from 'styled-components';
@@ -25,6 +25,7 @@ import {
   GrayTextButton,
   SmallButton,
   GreenSmallButtonBlock,
+  InlineErrorIcon,
 } from '../core/Button';
 import PrimarySelect from '../core/Select';
 import {
@@ -37,7 +38,9 @@ import Loading from '../core/Loading';
 import ErrorMessage from '../core/Error';
 import { InvertedSmallButtonLink } from '../core/Link';
 import { FlexBareContainer } from '../core/Container';
-import { generateRandomId } from '../../util/Utility';
+import { generateRandomId, validIdentifier } from '../../util/Utility';
+import { HoverContainer, HoverElement, HoverTooltip } from '../core/HoverTooltip';
+import { Coordinate } from '../special/FloatingCircle';
 
 const MainContent = styled.div`
   text-align: left;
@@ -62,6 +65,23 @@ const SettingsContainer = styled.div`
   border-radius: 10px;
   box-shadow: 0 -1px 4px rgba(0, 0, 0, 0.12);
   background: ${({ theme }) => theme.colors.white};
+`;
+
+type ShowError = {
+  show: boolean,
+};
+
+const HoverContainerErrorIcon = styled(HoverContainer).attrs((props: ShowError) => ({
+  style: {
+    display: `${props.show ? 'inline-block' : 'none'}`,
+  },
+}))<ShowError>`
+  margin: 0 0.5rem 0 0;
+`;
+
+const HoverElementErrorIcon = styled(HoverElement)`
+  width: 1rem;
+  height: 1rem;
 `;
 
 const SettingsContainerRelative = styled(SettingsContainer)`
@@ -154,6 +174,17 @@ function ProblemDisplay(props: ProblemDisplayParams) {
   const [newProblem, setNewProblem] = useState<Problem>(problem);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [mousePosition, setMousePosition] = useState<Coordinate>({ x: 0, y: 0 });
+  const [hoverVisible, setHoverVisible] = useState<boolean>(false);
+
+  // Get current mouse position.
+  const mouseMoveHandler = useCallback((e: MouseEvent) => {
+    setMousePosition({ x: e.pageX, y: e.pageY });
+  }, [setMousePosition]);
+
+  useEffect(() => {
+    window.onmousemove = mouseMoveHandler;
+  }, [mouseMoveHandler]);
 
   const onDragEnd = (result: any) => {
     // dropped outside the list
@@ -274,6 +305,13 @@ function ProblemDisplay(props: ProblemDisplayParams) {
 
   return (
     <>
+      <HoverTooltip
+        visible={hoverVisible}
+        x={mousePosition.x}
+        y={mousePosition.y}
+      >
+        This variable name is likely invalid
+      </HoverTooltip>
       <MainContent>
         <FlexBareContainer>
           <SmallHeaderText>Problem</SmallHeaderText>
@@ -448,6 +486,19 @@ function ProblemDisplay(props: ProblemDisplayParams) {
                 onChange={(e) => handleInputChange(index,
                   e.target.value, newProblem.problemInputs[index].type)}
               />
+
+              <HoverContainerErrorIcon
+                show={!validIdentifier(newProblem.problemInputs[index].name)}
+              >
+                <HoverElementErrorIcon
+                  enabled={validIdentifier(newProblem.problemInputs[index].name)}
+                  onMouseEnter={() => setHoverVisible(true)}
+                  onMouseLeave={() => setHoverVisible(false)}
+                />
+                <InlineErrorIcon>
+                  error_outline
+                </InlineErrorIcon>
+              </HoverContainerErrorIcon>
 
               <PrimarySelect
                 onChange={(e) => handleInputChange(

--- a/frontend/src/util/Utility.ts
+++ b/frontend/src/util/Utility.ts
@@ -3,6 +3,9 @@ import { removeUser } from '../api/Room';
 import { disconnect } from '../api/Socket';
 import { errorHandler } from '../api/Error';
 
+// Require validator for identifiers as no types are provided.
+const validateIdentifier = require('valid-identifier');
+
 /**
  * Check whether all keys in param exist in location.state
  */
@@ -50,3 +53,17 @@ export const leaveRoom = (history: any, roomId: string, user: User | null) => {
     });
   }
 };
+
+// Return true iff the character is a letter.
+const isLetter = (character: string) => {
+  if (character.length !== 1) {
+    return false;
+  }
+
+  // Character is a letter iff the upper case does not equal lower case.
+  return character.toUpperCase() !== character.toLowerCase();
+};
+
+// Return true iff the variable is a valid identifier, and starts with a letter.
+export const validIdentifier = (identifier: string) => validateIdentifier(identifier)
+  && isLetter(identifier.charAt(0));

--- a/src/main/java/com/rocketden/main/exception/ProblemError.java
+++ b/src/main/java/com/rocketden/main/exception/ProblemError.java
@@ -14,6 +14,7 @@ public enum ProblemError implements ApiError {
     INCORRECT_INPUT_COUNT(HttpStatus.BAD_REQUEST, "Please specify the correct number of parameters for this problem."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "Please ensure each line of test case input/output is valid and is of the correct type."),
     INVALID_NUMBER_REQUEST(HttpStatus.BAD_REQUEST, "Please request a valid number of problems."),
+    INVALID_VARIABLE_NAME(HttpStatus.BAD_REQUEST, "Please ensure all variable names are valid for Java and Python."),
     EMPTY_FIELD(HttpStatus.BAD_REQUEST, "Please enter a value for each required field."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "A problem could not be found with the given criteria.");
 

--- a/src/main/java/com/rocketden/main/service/ProblemService.java
+++ b/src/main/java/com/rocketden/main/service/ProblemService.java
@@ -17,6 +17,7 @@ import com.rocketden.main.model.problem.ProblemIOType;
 import com.rocketden.main.model.problem.ProblemInput;
 import com.rocketden.main.model.problem.ProblemTestCase;
 import com.rocketden.main.service.generators.DefaultCodeGeneratorService;
+import com.rocketden.main.util.Utility;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -65,10 +66,12 @@ public class ProblemService {
 
         // Add all problem inputs in list.
         for (ProblemInputDto problemInput : request.getProblemInputs()) {
-            if (problemInput != null) {
-                problem.addProblemInput(ProblemMapper.toProblemInputEntity(problemInput));
-            } else {
+            if (problemInput == null) {
                 throw new ApiException(ProblemError.BAD_INPUT);
+            } else if (!Utility.validateIdentifier(problemInput.getName())) {
+                throw new ApiException(ProblemError.INVALID_VARIABLE_NAME);
+            } else {
+                problem.addProblemInput(ProblemMapper.toProblemInputEntity(problemInput));
             }
         }
 
@@ -116,6 +119,10 @@ public class ProblemService {
 
         problem.getProblemInputs().clear();
         for (ProblemInputDto problemInput : updatedProblem.getProblemInputs()) {
+            if (!Utility.validateIdentifier(problemInput.getName())) {
+                throw new ApiException(ProblemError.INVALID_VARIABLE_NAME);
+            }
+
             problem.addProblemInput(ProblemMapper.toProblemInputEntity(problemInput));
         }
 

--- a/src/main/java/com/rocketden/main/util/Utility.java
+++ b/src/main/java/com/rocketden/main/util/Utility.java
@@ -1,8 +1,14 @@
 package com.rocketden.main.util;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.lang.model.SourceVersion;
 
 import com.rocketden.main.dao.RoomRepository;
 import com.rocketden.main.dao.UserRepository;
@@ -13,6 +19,15 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class Utility {
+
+    // Set of all Python keywords to prevent invalid variable names.
+    private static final Set<String> PYTHON_KEYWORDS =
+        Stream.of("False", "await", "else", "import", "pass", "None", "break",
+        "except", "in", "raise", "True", "class", "finally", "is", "return",
+        "and", "continue", "for", "lambda", "try", "as", "def", "from",
+        "nonlocal", "while", "assert", "del", "global", "not", "with", "async",
+        "elif", "if", "or", "yield")
+        .collect(Collectors.toCollection(HashSet::new));
 
     // List notifications that require an initiator.
     public static final List<NotificationType> initiatorNotifications =
@@ -84,5 +99,36 @@ public class Utility {
             default:
                 throw new IllegalArgumentException(String.format("The provided id type of %s is invalid.", idType));
         }
+    }
+
+    /**
+     * Check if the String is a valid identifier / variable name in Java and
+     * Python, as well as ensuring that is starts with a letter.
+     * 
+     * @param identifier the proposed variable name
+     * @return a boolean verifying whether the identifier is a valid variable
+     * name
+     */
+    public static boolean validateIdentifier(String identifier) {
+        if (identifier == null || identifier.isEmpty()) {
+            return false;
+        }
+
+        return SourceVersion.isIdentifier(identifier)
+            && SourceVersion.isName(identifier)
+            && !SourceVersion.isKeyword(identifier)
+            && isLetter(identifier.charAt(0))
+            && !PYTHON_KEYWORDS.contains(identifier);
+    }
+
+    /**
+     * Check if the character is a letter by determining if the toUpperCase
+     * function does not return the same character as toLowerCase.
+     * 
+     * @param c the character in question
+     * @return a boolean verifying whether c is a letter
+     */
+    private static boolean isLetter(Character c) {
+        return Character.toUpperCase(c) != Character.toLowerCase(c);
     }
 }

--- a/src/test/java/com/rocketden/main/api/ProblemTests.java
+++ b/src/test/java/com/rocketden/main/api/ProblemTests.java
@@ -286,7 +286,7 @@ class ProblemTests {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", "rocket rocket", "12", "$Hello", "jimmy=neutron"})
+    @ValueSource(strings = {"finally", "void", "throw", "EP<>", "new"})
     public void editProblemInvalidIdentifier(String inputName) throws Exception {
         ProblemDto problemDto = createSingleProblem();
 
@@ -340,7 +340,7 @@ class ProblemTests {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", "rocket rocket", "12", "$Hello", "jimmy=neutron"})
+    @ValueSource(strings = {"False", "try", "jeremy ", "-minus", "@annotation"})
     public void createProblemInvalidIdentifier(String inputName) throws Exception {
         CreateProblemRequest request = new CreateProblemRequest();
         request.setName(NAME);

--- a/src/test/java/com/rocketden/main/api/ProblemTests.java
+++ b/src/test/java/com/rocketden/main/api/ProblemTests.java
@@ -27,6 +27,8 @@ import com.rocketden.main.model.problem.ProblemIOType;
 import com.rocketden.main.util.UtilityTestMethods;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -283,6 +285,34 @@ class ProblemTests {
         assertEquals(ERROR.getResponse(), response);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"", "rocket rocket", "12", "$Hello", "jimmy=neutron"})
+    public void editProblemInvalidIdentifier(String inputName) throws Exception {
+        ProblemDto problemDto = createSingleProblem();
+
+        List<ProblemInputDto> problemInputs = new ArrayList<>();
+        ProblemInputDto problemInput = new ProblemInputDto();
+        problemInput.setName(inputName);
+        problemInput.setType(ProblemIOType.STRING);
+        problemInputs.add(problemInput);
+        problemDto.setProblemInputs(problemInputs);
+
+        ApiError ERROR = ProblemError.INVALID_VARIABLE_NAME;
+
+        // Edit problem with new values
+        String endpoint = String.format(PUT_PROBLEM_EDIT, problemDto.getProblemId());
+        MvcResult result = this.mockMvc.perform(put(endpoint)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(UtilityTestMethods.convertObjectToJsonString(problemDto)))
+                .andDo(print()).andExpect(status().is(ERROR.getStatus().value()))
+                .andReturn();
+
+        String jsonResponse = result.getResponse().getContentAsString();
+        ApiErrorResponse actual = UtilityTestMethods.toObject(jsonResponse, ApiErrorResponse.class);
+
+        assertEquals(ERROR.getResponse(), actual);
+    }
+
     @Test
     public void createProblemBadInput() throws Exception {
         CreateProblemRequest request = new CreateProblemRequest();
@@ -296,6 +326,36 @@ class ProblemTests {
         request.setOutputType(IO_TYPE);
 
         ApiError ERROR = ProblemError.BAD_INPUT;
+
+        MvcResult result = this.mockMvc.perform(post(POST_PROBLEM_CREATE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(UtilityTestMethods.convertObjectToJsonString(request)))
+                .andDo(print()).andExpect(status().is(ERROR.getStatus().value()))
+                .andReturn();
+
+        String jsonResponse = result.getResponse().getContentAsString();
+        ApiErrorResponse actual = UtilityTestMethods.toObject(jsonResponse, ApiErrorResponse.class);
+
+        assertEquals(ERROR.getResponse(), actual);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "rocket rocket", "12", "$Hello", "jimmy=neutron"})
+    public void createProblemInvalidIdentifier(String inputName) throws Exception {
+        CreateProblemRequest request = new CreateProblemRequest();
+        request.setName(NAME);
+        request.setDescription(DESCRIPTION);
+        request.setDifficulty(ProblemDifficulty.HARD);
+
+        List<ProblemInputDto> problemInputs = new ArrayList<>();
+        ProblemInputDto problemInput = new ProblemInputDto();
+        problemInput.setName(inputName);
+        problemInput.setType(ProblemIOType.STRING);
+        problemInputs.add(problemInput);
+        request.setProblemInputs(problemInputs);
+        request.setOutputType(IO_TYPE);
+
+        ApiError ERROR = ProblemError.INVALID_VARIABLE_NAME;
 
         MvcResult result = this.mockMvc.perform(post(POST_PROBLEM_CREATE)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
+++ b/src/test/java/com/rocketden/main/service/ProblemServiceTests.java
@@ -422,7 +422,7 @@ public class ProblemServiceTests {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", "rocket rocket", "12", "$Hello", "jimmy=neutron"})
+    @ValueSource(strings = {"class", "true", " ", "()", "\\"})
     public void editProblemInvalidIdentifier(String inputName) {
         Problem problem = new Problem();
         problem.setName(NAME);

--- a/src/test/java/com/rocketden/main/util/UtilityTests.java
+++ b/src/test/java/com/rocketden/main/util/UtilityTests.java
@@ -89,7 +89,7 @@ public class UtilityTests {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", "rocket rocket", "12", "$Hello", "jimmy=neutron"})
+    @ValueSource(strings = {"await", "7del", "finally", "is", "elif"})
     public void validateIdentifierFalse(String inputName) {
         assertFalse(Utility.validateIdentifier(inputName));
     }

--- a/src/test/java/com/rocketden/main/util/UtilityTests.java
+++ b/src/test/java/com/rocketden/main/util/UtilityTests.java
@@ -8,6 +8,8 @@ import com.rocketden.main.service.UserService;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -17,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -83,5 +86,17 @@ public class UtilityTests {
     @Test
     public void generateUserIdInvalidType() {
         assertThrows(IllegalArgumentException.class, () -> utility.generateUniqueId(UserService.USER_ID_LENGTH, "INVALID_KEY"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "rocket rocket", "12", "$Hello", "jimmy=neutron"})
+    public void validateIdentifierFalse(String inputName) {
+        assertFalse(Utility.validateIdentifier(inputName));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"rocket", "rocketrocket", "hi12", "H$ello", "jimmyNeutron"})
+    public void validateIdentifierTrue(String inputName) {
+        assertTrue(Utility.validateIdentifier(inputName));
     }
 }


### PR DESCRIPTION
### List of Changes:
- Add frontend check using the [valid-identifier](https://www.npmjs.com/package/valid-identifier) npm module, and add `HoverTooltip` to the create and edit problem pages for invalid parameter names.
- Add backend verification for Java through [`isIdentifier`, `isKeyword`, and `isName`](https://docs.oracle.com/javase/8/docs/api/javax/lang/model/SourceVersion.html), as well as checking against the list of case-sensitive [Python keywords](https://www.programiz.com/python-programming/keyword-list).
- Add parameterized integration and unit tests.

### Notes:
- I closed a duplicate #132 PR because it added and removed 17,517 lines; I noticed this was because when I ran `npm i valid-identifier` in the `frontend` folder, it removed those lines, but when I ran `./mvnw spring-boot:run`, it added them back in. I'm not sure why this might be, but to fix that problem I did both actions in the same commit, so there shouldn't be any accidentally very large commits in this PR.
- I changed how `HoverTooltip` displays as the `InlineErrorIcon` is never `disabled`, so I can use `onMouseEnter`, `onMouseMove`, and `onMouseLeave` directly on that object. This fixed the bug which caused the frontend "Difficulty" buttons to toggle rapidly on hover, which I think may have been because the state was rapidly refreshing.
  - When using the hover tooltip on other pages, it's important to note that if something is not disabled, then the outer `div` and absolutely-positioned hover element are not necessary.
- On the `mouseMoveHandler` function, I use a type `any` because I could not get the types for that function to work - it works with `any` though, so as long as that's ok this should work out.
- I made an additional restriction that all parameter names must start with a letter (using [this method](https://stackoverflow.com/a/32567789/7517518)), as I thought this would improve readability.
- As we add more languages, we may need to check against additional keywords. I thought of checking valid variable name using the [Python method](https://stackoverflow.com/questions/36330860/pythonically-check-if-a-variable-name-is-valid) as well, but I thought that may be too complicated to incorporate.

### Screencast and Images:

[Invalid Parameter Names on Problem Pages](https://www.loom.com/share/c958a1a6a74b4839b6a8ec027b8463a9)

**Create Page Invalid Parameter with Hover**
<img width="1276" alt="Create Page Invalid Parameter" src="https://user-images.githubusercontent.com/7987279/113493917-a6d74e00-9498-11eb-8e9d-13ca6b09606a.png">

**Edit Page Invalid Parameter with Error**
<img width="1273" alt="Edit Page Invalid Parameter with Error" src="https://user-images.githubusercontent.com/7987279/113494366-64b00b80-949c-11eb-84ef-f831ee31c806.png">
