### PR TITLE
Create the local database and tester service

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,18 +20,3 @@ jobs:
         java-version: 11
     - name: Build with Maven
       run: ./mvnw test
-
-  deploy:
-    needs: test
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    env:
-      JASYPT_ENCRYPTOR_PASSWORD: ${{secrets.JASYPT_ENCRYPTOR_PASSWORD}}
-      PROBLEM_ACCESS_PASSWORD: ${{secrets.PROBLEM_ACCESS_PASSWORD}}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: akhileshns/heroku-deploy@v3.4.6
-        with:
-          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
-          heroku_app_name: "codejoust"
-          heroku_email: "support@codejoust.co"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,4 +3,5 @@
   "eslint.workingDirectories": [
     "./frontend"
   ],
+  "java.compile.nullAnalysis.mode": "automatic",
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4435,9 +4435,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001291",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
-      "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA=="
+      "version": "1.0.30001457",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001457.tgz",
+      "integrity": "sha512-SDIV6bgE1aVbK6XyxdURbUE89zY7+k1BBBaOwYwkNCglXlel/E7mELiHC64HQ+W0xSKlqWhV9Wh7iHxUjMs4fA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -22049,9 +22059,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001291",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
-      "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA=="
+      "version": "1.0.30001457",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001457.tgz",
+      "integrity": "sha512-SDIV6bgE1aVbK6XyxdURbUE89zY7+k1BBBaOwYwkNCglXlel/E7mELiHC64HQ+W0xSKlqWhV9Wh7iHxUjMs4fA=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/pom.xml
+++ b/pom.xml
@@ -105,9 +105,14 @@
     </dependency>
     <!-- Logging dependency for testing -->
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.19.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.19.0</version>
     </dependency>
     <!-- H2 database for testing -->
     <dependency>
@@ -118,7 +123,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.6</version>
+      <version>2.10.1</version>
     </dependency>
     <!-- Hikari Connection Pool -->
     <dependency>
@@ -210,6 +215,7 @@
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
+            <?m2e execute onConfiguration?>
             <phase>generate-resources</phase>
             <configuration>
               <target>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <optional>true</optional>
+      <version>1.18.22</version>
     </dependency>
     <!-- Encryption for database configuration -->
     <dependency>

--- a/src/main/java/com/codejoust/main/Main.java
+++ b/src/main/java/com/codejoust/main/Main.java
@@ -29,6 +29,8 @@ public class Main {
 		if (keyfile == null) {
 			log.error("Could not find the firebase keyfile in an environment variable.");
 			log.error("Please set this value before launching the program.");
+
+			// Exit the program with unsuccessful status; return used to satisfy linter warning.
 			System.exit(1);
 			return;
 		}

--- a/src/main/java/com/codejoust/main/Main.java
+++ b/src/main/java/com/codejoust/main/Main.java
@@ -30,6 +30,7 @@ public class Main {
 			log.error("Could not find the firebase keyfile in an environment variable.");
 			log.error("Please set this value before launching the program.");
 			System.exit(1);
+			return;
 		}
 
 		InputStream stream = new ByteArrayInputStream(keyfile.getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/com/codejoust/main/service/RoomService.java
+++ b/src/main/java/com/codejoust/main/service/RoomService.java
@@ -358,7 +358,8 @@ public class RoomService {
             problemsHaveChanged = checkSelectedProblemChanges(selectedProblems, room);
         }
 
-        if (problemsHaveChanged) {
+        // Secondary check that selected problems are not null is superfluous but removes linter warning.
+        if (problemsHaveChanged && selectedProblems != null) {
             List<Problem> newProblems = new ArrayList<>();
             for (SelectableProblemDto selected : selectedProblems) {
                 Problem problem = problemService.getProblemEntity(selected.getProblemId());

--- a/src/main/java/com/codejoust/main/service/SubmitService.java
+++ b/src/main/java/com/codejoust/main/service/SubmitService.java
@@ -91,8 +91,6 @@ public class SubmitService {
 
     // Test the submission and send a socket update.
     public SubmissionDto runCode(Game game, SubmissionRequest request) {
-        String userId = request.getInitiator().getUserId();
-
         PlayerCode playerCode = new PlayerCode();
         playerCode.setCode(request.getCode());
         playerCode.setLanguage(request.getLanguage());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 # Set up database connection.
 spring.jpa.hibernate.ddl-auto=update
 # Passwords for keystore and datastore encrypted, and URL thus hidden. See documentation on CodeJoust team Google Docs for the datasource URL format.
-spring.datasource.url=ENC(eXF8tUMIUUEhSC0wHMZHMdyn8IDybnTn96AuBe/zxgBy+SrAKcMd+bP2vEL0SLVgWeEgdxoWLR/a0WsFqCXhkBlHI5gfZGy4aSyrDXvFewS8KzOkpb4GJRSI33+aVrZKkELX6OoEVvTWGG8++Svgp69+oUdiO4dnPBMtlQKs+G358c1xiIp2IbqR+qmoT1DwxABN3NdQnKCnFubgm3HfcMlRTPTRg1Hv7QDmeP5t0ru5lfaBjmlXIPvhdyvyM+6vzaxiFf9RjSjMxUX0Wx3qtgwzHcTDGjqX11RlHeBC3q0pp8fduZ7O5EYrQ1/LV5cnS1njVf5b7ZgK2j0tKusByxizL0BU8Pivbru9mYA/OoBw4jSMSUrV4ps5Rz82ku4/nh5nW9zXdLbm4BxLM/qHagjaJelieXPnrCArgUzmgk8=)
-spring.datasource.username=codejoust
-spring.datasource.password=ENC(epj2Y3gphq6164k15apQphtgq8aj12qZ)
+spring.datasource.url=jdbc:mysql://127.0.0.1:3306/main?user=root
+spring.datasource.username=root
+spring.datasource.password=ENC(kzpQEO8PZLdClM5wCYlJZ38iHjDyJdRCWVFUkkvHiqI=)
 
 # Enable OSIV (Open Session in View). This is the default setting.
 spring.jpa.open-in-view=false
@@ -16,7 +16,7 @@ spring.datasource.hikari.maximumPoolSize=10
 
 # Whether to return dummy submission when tester service is unavailable
 tester.debugMode=false
-tester.url=ENC(Ye3dZQqfPaGR/sBNlWu+oV2MEJJWaHQay2wULRZLZxzkVNd6hJ/7g3ecJ4S8JZSN)
+tester.url=http://localhost:8010/api/v1/runner
 
 # Whether to mock firebase service for testing purposes
 firebase.debugMode=false

--- a/src/test/java/com/codejoust/main/api/GameTests.java
+++ b/src/test/java/com/codejoust/main/api/GameTests.java
@@ -38,7 +38,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/codejoust/main/mapper/GameMapperTests.java
+++ b/src/test/java/com/codejoust/main/mapper/GameMapperTests.java
@@ -19,7 +19,6 @@ import com.codejoust.main.dto.game.PlayerDto;
 import com.codejoust.main.dto.game.SubmissionDto;
 import com.codejoust.main.dto.game.SubmissionResultDto;
 import com.codejoust.main.dto.problem.ProblemDto;
-import com.codejoust.main.dto.problem.ProblemMapper;
 import com.codejoust.main.dto.problem.ProblemTestCaseDto;
 import com.codejoust.main.dto.room.RoomMapper;
 import com.codejoust.main.dto.user.UserMapper;

--- a/src/test/java/com/codejoust/main/task/EndGameTimerTaskTests.java
+++ b/src/test/java/com/codejoust/main/task/EndGameTimerTaskTests.java
@@ -18,7 +18,7 @@ import com.codejoust.main.service.SocketService;
 
 import com.codejoust.main.util.EndGameTimerTask;
 import com.codejoust.main.util.TestFields;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;

--- a/src/test/java/com/codejoust/main/task/NotificationTimerTaskTests.java
+++ b/src/test/java/com/codejoust/main/task/NotificationTimerTaskTests.java
@@ -1,11 +1,15 @@
 package com.codejoust.main.task;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
+import java.time.Instant;
 import java.util.Timer;
 
 import com.codejoust.main.dto.game.GameNotificationDto;
@@ -17,7 +21,9 @@ import com.codejoust.main.util.NotificationTimerTask;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -55,12 +61,6 @@ public class NotificationTimerTaskTests {
     public void notificationTimerTaskSocketMessage() {
         MockitoAnnotations.initMocks(this);
 
-        GameNotificationDto notificationDto = new GameNotificationDto();
-        notificationDto.setInitiator(null);
-        notificationDto.setTime(null);
-        notificationDto.setNotificationType(NotificationType.TIME_LEFT);
-        notificationDto.setContent(TIME_LEFT);
-
         Timer timer = new Timer();
         NotificationTimerTask notificationTimerTask = new NotificationTimerTask(socketService, ROOM_ID, TIME_LEFT);
         timer.schedule(notificationTimerTask, (long) 1 * 1000);
@@ -70,8 +70,15 @@ public class NotificationTimerTaskTests {
          * but is called 1 second later (wait for timer task).
          */
 
-        verify(socketService, never()).sendSocketUpdate(eq(ROOM_ID), eq(notificationDto));
+        verify(socketService, never()).sendSocketUpdate(eq(ROOM_ID), Mockito.any(GameNotificationDto.class));
 
-        verify(socketService, timeout(1500)).sendSocketUpdate(eq(ROOM_ID), eq(notificationDto));
+        ArgumentCaptor<GameNotificationDto> argument = ArgumentCaptor.forClass(GameNotificationDto.class);
+        verify(socketService, timeout(1500)).sendSocketUpdate(eq(ROOM_ID), argument.capture());
+        GameNotificationDto notificationDtoResult = argument.getValue();
+        assertNull(notificationDtoResult.getInitiator());
+        assertEquals(NotificationType.TIME_LEFT, notificationDtoResult.getNotificationType());
+        assertEquals(TIME_LEFT, notificationDtoResult.getContent());
+        assertTrue(Instant.now().isAfter(notificationDtoResult.getTime())
+            || Instant.now().minusSeconds((long) 1).isBefore(notificationDtoResult.getTime()));
     }
 }

--- a/src/test/java/com/codejoust/main/task/NotificationTimerTaskTests.java
+++ b/src/test/java/com/codejoust/main/task/NotificationTimerTaskTests.java
@@ -14,7 +14,7 @@ import com.codejoust.main.game_object.NotificationType;
 import com.codejoust.main.service.SocketService;
 
 import com.codejoust.main.util.NotificationTimerTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;

--- a/src/test/java/com/codejoust/main/util/ProblemTestMethods.java
+++ b/src/test/java/com/codejoust/main/util/ProblemTestMethods.java
@@ -8,7 +8,6 @@ import com.codejoust.main.dto.problem.ProblemTagDto;
 import com.codejoust.main.dto.problem.ProblemTestCaseDto;
 import com.codejoust.main.model.problem.ProblemDifficulty;
 import com.codejoust.main.model.problem.ProblemIOType;
-import com.codejoust.main.model.problem.ProblemTag;
 import com.codejoust.main.service.SubmitService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -166,20 +165,20 @@ public class ProblemTestMethods {
      * @throws Exception if anything wrong occurs
      */
     public static ProblemTagDto createSingleProblemTag(MockMvc mockMvc) throws Exception {
-        ProblemTag problemTag = new ProblemTag();
-        problemTag.setName(TestFields.TAG_NAME);
+        ProblemTagDto problemTagDto = new ProblemTagDto();
+        problemTagDto.setName(TestFields.TAG_NAME);
 
         MvcResult problemTagResult = mockMvc.perform(post(POST_PROBLEM_TAG_CREATE)
                 .header(HttpHeaders.AUTHORIZATION, TestFields.TOKEN)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .content(UtilityTestMethods.convertObjectToJsonString(problemTag)))
+                .content(UtilityTestMethods.convertObjectToJsonString(problemTagDto)))
                 .andDo(print()).andExpect(status().isCreated())
                 .andReturn();
 
         String problemTagJsonResponse = problemTagResult.getResponse().getContentAsString();
         ProblemTagDto problemTagActual = UtilityTestMethods.toObject(problemTagJsonResponse, ProblemTagDto.class);
 
-        assertEquals(problemTag.getName(), problemTagActual.getName());
+        assertEquals(problemTagDto.getName(), problemTagActual.getName());
 
         return problemTagActual;
     }


### PR DESCRIPTION
### List of Changes:

- Update the reference URLs to build CodeJoust completely locally - Tester service and database included.
- Address linter warnings by removing unused imports and adding null checks.
  - The null checks were superfluous in these cases, so I added comments for additional clarification.
- Remove the deployment pipeline on `workflow.yml`.
  - This can be added back with relevant adjustments once this Tester repository is re-deployed.
- Fix [log4j](https://github.com/CodeJoustHQ/main/security/dependabot/80) and [gson](https://github.com/CodeJoustHQ/main/security/dependabot/65) warnings.
- Address issues on tests consistently failing - they should hopefully now always pass, whether run on Github Actions, Maven, or VSCode.

### Notes:

- I fixed the imports on testing files to `import org.junit.jupiter.api.Test;` as they were not being detected by Maven.
- Upgrading the lombok dependency version to remove `IllegalAccessError`, as referenced in [this Stack Overflow](https://stackoverflow.com/a/66981165/7517518) post.
- Note for running with environment variables on new Macbook Air setup: environment variables are stored in `~/.zshenv`, and you can run `source ~/.zshenv` for help.
- I also fixed Java runtime warnings on my local machine via [this process](https://github.com/redhat-developer/vscode-java/wiki/JDK-Requirements#java.configuration.runtimes) which configures JDK runtimes.

### Screencast and Images:

None.
